### PR TITLE
Multibinaries are now generated with the right tool on recent SDK

### DIFF
--- a/mppa256/src/FAST/makefile
+++ b/mppa256/src/FAST/makefile
@@ -4,7 +4,6 @@
 
 # Source files.
 SRC_MASTER = $(wildcard master/*.c)
-          
 SRC_SLAVE =  $(wildcard slave/*.c)
 
 # Executable.
@@ -15,7 +14,7 @@ EXEC = fast
 
 # Builds kernel.
 all: master slave
-	$(MPPADIR)/bin/createImage.rb --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
+	$(MPPADIR)/bin/k1-create-multibinary --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
 	rm -f $(EXEC).master
 	rm -f $(EXEC).slave
 
@@ -26,7 +25,7 @@ master: $(SRC_MASTER)
 # Builds slave.
 slave: $(SRC_SLAVE)
 	$(CC) -mos=nodeos $(CFLAGS) $(SRC_SLAVE) $(LIBSRCDIR)/*.c -o $(EXEC).slave $(LIBS) -fopenmp
-	
+
 # Cleans compilation files.
 clean:
 	rm -f $(BINDIR)/$(EXEC).mppa.mpk

--- a/mppa256/src/FN/makefile
+++ b/mppa256/src/FN/makefile
@@ -14,7 +14,7 @@ EXEC = fn
 
 # Builds kernel.
 all: master slave
-	$(MPPADIR)/bin/createImage.rb --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
+	$(MPPADIR)/bin/k1-create-multibinary --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
 	rm -f $(EXEC).master
 	rm -f $(EXEC).slave
 
@@ -25,7 +25,7 @@ master: $(SRC_MASTER)
 # Builds slave.
 slave: $(SRC_SLAVE)
 	$(CC) -mos=nodeos $(CFLAGS) $(SRC_SLAVE) $(LIBSRCDIR)/*.c -o $(EXEC).slave $(LIBS) -fopenmp
-	
+
 # Cleans compilation files.
 clean:
 	rm -f $(BINDIR)/$(EXEC).mppa.mpk

--- a/mppa256/src/GF/makefile
+++ b/mppa256/src/GF/makefile
@@ -4,7 +4,6 @@
 
 # Source files.
 SRC_MASTER = $(wildcard master/*.c)
-          
 SRC_SLAVE =  $(wildcard slave/*.c)
 
 # Executable.
@@ -15,7 +14,7 @@ EXEC = gf
 
 # Builds kernel.
 all: master slave
-	$(MPPADIR)/bin/createImage.rb --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
+	$(MPPADIR)/bin/k1-create-multibinary --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
 	rm -f $(EXEC).master
 	rm -f $(EXEC).slave
 
@@ -26,7 +25,7 @@ master: $(SRC_MASTER)
 # Builds slave.
 slave: $(SRC_SLAVE)
 	$(CC) -mos=nodeos $(CFLAGS) $(SRC_SLAVE) $(LIBSRCDIR)/*.c -o $(EXEC).slave $(LIBS) -fopenmp
-	
+
 # Cleans compilation files.
 clean:
 	rm -f $(BINDIR)/$(EXEC).mppa.mpk

--- a/mppa256/src/IS/makefile
+++ b/mppa256/src/IS/makefile
@@ -4,7 +4,6 @@
 
 # Source files.
 SRC_MASTER = $(wildcard master/*.c)
-          
 SRC_SLAVE =  $(wildcard slave/*.c)
 
 # Executable.
@@ -15,7 +14,7 @@ EXEC = is
 
 # Builds kernel.
 all: master slave
-	$(MPPADIR)/bin/createImage.rb --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
+	$(MPPADIR)/bin/k1-create-multibinary --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
 	rm -f $(EXEC).master
 	rm -f $(EXEC).slave
 
@@ -26,7 +25,7 @@ master: $(SRC_MASTER)
 # Builds slave.
 slave: $(SRC_SLAVE)
 	$(CC) -mos=nodeos $(CFLAGS) $(SRC_SLAVE) $(LIBSRCDIR)/*.c -o $(EXEC).slave $(LIBS) -fopenmp
-	
+
 # Cleans compilation files.
 clean:
 	rm -f $(BINDIR)/$(EXEC).mppa.mpk

--- a/mppa256/src/KM/makefile
+++ b/mppa256/src/KM/makefile
@@ -4,7 +4,6 @@
 
 # Source files.
 SRC_MASTER = $(wildcard master/*.c)
-          
 SRC_SLAVE =  $(wildcard slave/*.c)
 
 # Executable.
@@ -15,7 +14,7 @@ EXEC = km
 
 # Builds kernel.
 all: master slave
-	$(MPPADIR)/bin/createImage.rb --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
+	$(MPPADIR)/bin/k1-create-multibinary --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
 	rm -f $(EXEC).master
 	rm -f $(EXEC).slave
 
@@ -26,7 +25,7 @@ master: $(SRC_MASTER)
 # Builds slave.
 slave: $(SRC_SLAVE)
 	$(CC) -mos=nodeos $(CFLAGS) $(SRC_SLAVE) $(LIBSRCDIR)/*.c -o $(EXEC).slave $(LIBS) -fopenmp
-	
+
 # Cleans compilation files.
 clean:
 	rm -f $(BINDIR)/$(EXEC).mppa.mpk

--- a/mppa256/src/LU/makefile
+++ b/mppa256/src/LU/makefile
@@ -4,7 +4,6 @@
 
 # Source files.
 SRC_MASTER = $(wildcard master/*.c)
-          
 SRC_SLAVE =  $(wildcard slave/*.c)
 
 # Executable.
@@ -15,7 +14,7 @@ EXEC = lu
 
 # Builds kernel.
 all: master slave
-	$(MPPADIR)/bin/createImage.rb --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
+	$(MPPADIR)/bin/k1-create-multibinary --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
 	rm -f $(EXEC).master
 	rm -f $(EXEC).slave
 
@@ -26,7 +25,7 @@ master: $(SRC_MASTER)
 # Builds slave.
 slave: $(SRC_SLAVE)
 	$(CC) -mos=nodeos $(CFLAGS) $(SRC_SLAVE) $(LIBSRCDIR)/*.c -o $(EXEC).slave $(LIBS) -fopenmp
-	
+
 # Cleans compilation files.
 clean:
 	rm -f $(BINDIR)/$(EXEC).mppa.mpk

--- a/mppa256/src/TSP/makefile
+++ b/mppa256/src/TSP/makefile
@@ -18,7 +18,7 @@ DEBUG = -UDEBUG
 
 # Builds kernel.
 all: master slave
-	$(MPPADIR)/bin/createImage.rb --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
+	$(MPPADIR)/bin/k1-create-multibinary --toolchain $(MPPADIR) --clusters=$(EXEC).slave --boot=$(EXEC).master -T $(BINDIR)/$(EXEC).mppa.mpk
 	rm -f $(EXEC).master
 	rm -f $(EXEC).slave
 


### PR DESCRIPTION
Tool for generating multibinaries is not anymore "createImage.rb" but "k1-create-multibinary".
However, syntax was left unchanged.
