### PR TITLE
Fixed "KM" Kernel on x86 platform

### DIFF
--- a/x86/src/KM/km.h
+++ b/x86/src/KM/km.h
@@ -1,96 +1,28 @@
-/*
- * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
- * 
- * km.h - K-means kernel library.
- */
-
 #ifndef _KM_H_
 #define _KM_H_
 
-	/*
-	 * Vector.
-	 */
-	struct vector
-	{
-		int size;        /* Size.     */
-		float *elements; /* Elements. */
-	};
-	
-	/*
-	 * Opaque pointer to a vector.
-	 */
-	typedef struct vector * vector_t;
-	
-	/*
-	 * Opaque pointer to a constant vector.
-	 */
-	typedef const struct vector * const_vector_t;
+#define CENTROIDS(i) \
+	(&centroids[(i)*dimension])
 
-	/*
-	 * Clusters data. 
-	 */
-	int *kmeans(vector_t *data, int npoints, int ncentroids, float mindistance);
-	
-	/*
-	 * Returns the size of a vector.
-	 */
-	#define vector_size(v) \
-		(((vector_t) (v))->size)
-	
-	/*
-	 * Clears a vector.
-	 */
-	extern void vector_clear(struct vector *v);
-	
-	/*
-	 * Creates a vector.
-	 */
-	extern vector_t vector_create(int n);
-	
-	/*
-	 * Destroys a vector.
-	 */
-	extern void vector_destroy(vector_t v);
-	
-	/*
-	 * Computes the euclidean distance between two points.
-	 */
-	extern float vector_distance(const_vector_t a, const_vector_t b);
-	
-	/*
-	 * Tests if two vectors are equal.
-	 */
-	extern int vector_equal(const_vector_t a, const_vector_t b);
-	
-	/*
-	 * Assigns a vector to another.
-	 */
-	extern vector_t vector_assign(vector_t v1, const_vector_t v2);
-	
-	/*
-	 * Subtracts two vectors.
-	 */
-	extern vector_t vector_sub(vector_t v1, const_vector_t v2);
-	
-	/*
-	 * Adds two vectors.
-	 */
-	extern vector_t vector_add(vector_t v1, const_vector_t v2);
-	
-	/*
-	 * Multiplies a vector by a scalar.
-	 */
-	extern vector_t vector_mult(vector_t v, float scalar);
-	
-	/*
-	 * Fills up vector with random numbers.
-	 */
-	extern vector_t vector_random(vector_t v);
+#define POINTS(i) \
+	(&points[(i)*dimension])
 
-	/*
-	 * Returns the element [i] in a vector.
-	 */
-	#define VECTOR(v, i) \
-		(((vector_t)(v))->elements[(i)])
+#define TMP_CENTROIDS(i) \
+	(tmp[(i)*dimension])
 
-#endif /* _KM_H_ */
+/* Clusters points. */
+int *kmeans(float *_points, int npoints, int ncentroids, int dimension);
+
+/* Assigns a vector to another. */
+extern void vector_assign(float *v1, float *v2);
+
+/* Computes the euclidean distance between two points. */
+extern float vector_distance(float *v1, float *v2);
+
+/* Multiplies a vector by a scalar. */
+extern void vector_mult(float *v, float scalar);
+
+/* Adds two vectors. */
+extern void vector_add(float *v1, float *v2);
+
+#endif

--- a/x86/src/KM/kmeans.c
+++ b/x86/src/KM/kmeans.c
@@ -1,200 +1,170 @@
-/*
- * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
- * 
- * kmeans.c - kmeans() implementation.
- */
-
+/* Kernel Include */
 #include <global.h>
-#include <math.h>
-#include <omp.h>
-#include <string.h>
 #include <util.h>
 #include "km.h"
 
-/* Kmeans data. */
-float mindistance;   /* Minimum distance.             */
-int npoints;         /* Number of points.             */
-vector_t *data;      /* Data being clustered.         */
-int ncentroids;      /* Number of clusters.           */
-int *map;            /* Map of clusters.              */
-vector_t *centroids; /* Data centroids.               */
-vector_t *tmp;       /* Temporary centroids.          */
-int *dirty;          /* Dirty centroid?               */
-int *too_far;        /* Are there any points too far? */
-int *has_changed;    /* has any centroid change?      */
+/* C And MPPA Library Includes*/
+#include <math.h>
+#include <omp.h>
+#include <string.h>
 
-/*
- * Populates clusters.
- */
-static void populate(void)
-{
-	int tid;        /* Thread ID.          */
-	int i, j;       /* Loop indexes.       */
-	float tmp;      /* Auxiliary variable. */
-	float distance; /* Distance.           */
-	
-	memset(too_far, 0, nthreads*sizeof(int));
-	
+#include <stdio.h>
+
+/* Kmeans data. */
+int dimension ;    /* Problem dimension         */
+int npoints;       /* Number of points.         */
+int ncentroids;    /* Number of clusters.       */
+int *map;          /* Map of clusters.          */
+float *points;     /* Data being clustered.     */
+float *centroids;  /* Data centroids.           */
+int *populations;  /* Clusters population.      */
+int *has_changed;  /* has any centroid change?  */
+
+static omp_lock_t *lock;
+
+static void populate() {
+	int tid;        /* Thread ID.             */
+	int i, j;       /* Loop indexes.          */
+	int lock_aux;   /* Lock auxiliar.         */
+	int init_map;   /* Point initial mapping. */
+	float tmp_dist; /* Temporary distance.    */
+	float distance; /* Distance.              */
+
+	/* Reset variables for new calculation. */
+	memset(populations, 0, ncentroids*sizeof(int));
+	memset(has_changed, 0, nthreads*sizeof(int));
+
 	/* Iterate over data points. */
-	#pragma omp parallel private(i, j, tmp, distance, tid) default(shared)
+	#pragma omp parallel private(i, j, tmp_dist, distance, tid, init_map, lock_aux) default(shared)
 	{
 		tid = omp_get_thread_num();
-		
+
 		#pragma omp for
-		for (i = 0; i < npoints; i++)
-		{	
-			distance = vector_distance(centroids[map[i]], data[i]);
-			
-			/* Look for closest cluster. */
-			for (j = 0; j < ncentroids; j++)
-			{	
+		for (i = 0; i < npoints; i++) {	
+			distance = vector_distance(CENTROIDS(map[i]), POINTS(i));
+			init_map = map[i];
+
+			/* Looking for closest cluster. */
+			for (j = 0; j < ncentroids; j++) {	
 				/* Point is in this cluster. */
 				if (j == map[i])
 					continue;
+						
+				tmp_dist = vector_distance(CENTROIDS(j), POINTS(i));
 					
-				tmp = vector_distance(centroids[j], data[i]);
-				
 				/* Found. */
-				if (tmp < distance)
-				{
+				if (tmp_dist < distance) {
 					map[i] = j;
-					distance = tmp;
-					
-					#pragma omp critical
-					dirty[j] = 1;
+					distance = tmp_dist;
 				}
 			}
-			
-			/* Cluster is too far away. */
-			if (distance > mindistance)
-				too_far[tid] = 1;
+
+			lock_aux = map[i] % nthreads;
+
+			omp_set_lock(&lock[lock_aux]);
+			populations[map[i]]++;
+			omp_unset_lock(&lock[lock_aux]);
+
+			if (map[i] != init_map)
+				has_changed[tid] = 1;
 		}
 	}
 }
 
-/*
- * Computes cluster's centroids.
- */
-static void compute_centroids(void)
-{
-	int tid;        /* Thread ID.          */
-	int i, j;       /* Loop indexes.       */
-	int population; /* Cluster population. */
-	
-	memset(has_changed, 0, nthreads*sizeof(int));
-	
+static void compute_centroids() {
+	int i;        /* Loop index.                 */
+	int lock_aux; /* Lock auxiliar.              */
+
+	/* Clear all centroids for recalculation. */
+	memset(CENTROIDS(0), 0, ncentroids*dimension*sizeof(float));
+
 	/* Compute means. */
-	#pragma omp parallel private(i, j, population, tid) default(shared) 
+	#pragma omp parallel private(i, lock_aux) default(shared) 
 	{	
-		tid = omp_get_thread_num();
-		
+		/* Computing centroids means. */
+		#pragma omp for 
+		for (i = 0; i < npoints; i++) {
+			lock_aux = map[i] % nthreads;
+			omp_set_lock(&lock[lock_aux]);
+			vector_add(CENTROIDS(map[i]), POINTS(i));
+			omp_unset_lock(&lock[lock_aux]);	
+		}
+
+		#pragma omp barrier
+
+		/* Computing centroids means. */
 		#pragma omp for
-		for (i = 0; i < ncentroids; i++)
-		{
-			/* Cluster did not change. */
-			if (!dirty[i])
-				continue;
-				
-			/* Initialize temporary vector.*/
-			vector_assign(tmp[tid], centroids[i]);
-			vector_clear(centroids[i]);
-			
-			/* Compute cluster's mean. */
-			population = 0;
-			for (j = 0; j < npoints; j++)
-			{
-				/* Not a member of this cluster. */
-				if (map[j] != i)
-					continue;			
-				
-				vector_add(centroids[i], data[j]);
-					
-				population++;
-			}		
-			if (population > 1)
-				vector_mult(centroids[i], 1.0/population);
-			
-			has_changed[tid] = 1;
+		for (i = 0; i < ncentroids; i++) {
+			if (populations[i] > 1)
+				vector_mult(CENTROIDS(i), 1.0/populations[i]);
 		}
 	}
-	
-	memset(dirty, 0, ncentroids*sizeof(int));
 }
 
-/*
- * Clusters data. 
- */
-int *kmeans(vector_t *_data, int _npoints, int _ncentroids, float _mindistance)
-{
+/* Sets centroids and begins to map points. */
+static void init_mapping() {
 	int i, j;  /* Loop index. */
-	int again; /* Loop again? */
-	
-	/* Setup parameters. */
-	data = _data;
-	npoints = _npoints;
-	ncentroids = _ncentroids;
-	mindistance = _mindistance;
-	
-	/* Create auxiliary structures. */
-	map  = scalloc(npoints, sizeof(int));
-	too_far = smalloc(nthreads*sizeof(int));
-	has_changed = smalloc(nthreads*sizeof(int));
-	dirty = smalloc(ncentroids*sizeof(int));
-	centroids = smalloc(ncentroids*sizeof(vector_t));
-	for (i = 0; i < ncentroids; i++)
-		centroids[i] = vector_create(vector_size(data[0]));
-	tmp = smalloc(nthreads*sizeof(vector_t));
-	for (i = 0; i < nthreads; i++)
-		tmp[i] = vector_create(vector_size(data[0]));
-	
+
 	/* Initialize mapping. */
 	for (i = 0; i < npoints; i++)
 		map[i] = -1;
 
 	/* Initialize centroids. */
-	for (i = 0; i < ncentroids; i++)
-	{
-		dirty[i] = 1;
+	for (i = 0; i < ncentroids; i++) {
 		j = randnum()%npoints;
-		vector_assign(centroids[i], data[j]);
+		vector_assign(CENTROIDS(i), POINTS(j));
 		map[j] = i;
 	}
 
 	/* Map unmapped data points. */
-	for (i = 0; i < npoints; i++)
-	{
+	for (i = 0; i < npoints; i++) {
 		if (map[i] < 0)
 			map[i] = randnum()%ncentroids;
 	}
-	
-	/* Cluster data. */
-	do
-	{
+}
+
+/* Clusters data. */
+int *kmeans(float *_points, int _npoints, int _ncentroids, int _dimension) {
+	int i;       /* Loop index. */
+	int again;   /* Loop again? */
+
+	/* Setup parameters. */
+	points = _points;
+	npoints = _npoints;
+	ncentroids = _ncentroids;
+	dimension = _dimension;
+
+	/* Allocate memory for auxiliary structures. */
+	map  = scalloc(npoints, sizeof(int));
+	centroids = smalloc(ncentroids*dimension*sizeof(float));
+	populations = smalloc(ncentroids*sizeof(int));
+	lock = smalloc (nthreads*sizeof(omp_lock_t));
+	has_changed = smalloc(nthreads*sizeof(int));
+
+	/* Initialize mapping. */
+	init_mapping();
+
+	omp_set_num_threads(nthreads);
+	for (i = 0; i < nthreads; i++)
+		omp_init_lock(&lock[i]);
+
+	/* Iterate over points until all clusters are defined. */
+	do {
 		populate();
 		compute_centroids();
 
-		/* Check if we need to loop. */
-		for (i = 0; i < nthreads; i++)
-		{
-			/* We will need another iteration. */
-			if (too_far[i] && has_changed[i])
-				break;		
+		for (i = 0; i < nthreads; i++){
+			if (has_changed[i] == 1)
+				break;
 		}
 
 		again = (i < nthreads) ? 1 : 0;
-
 	} while (again);
-	
-	/* House keeping.  */
-	for (i = 0; i < ncentroids; i++)
-		vector_destroy(centroids[i]);
+
+	/* House keeping. */
+	free(populations);
 	free(centroids);
-	for (i = 0; i < nthreads; i++)
-		vector_destroy(tmp[i]);
-	free(tmp);
-	free(too_far);
 	free(has_changed);
-	free(dirty);
-	
-	return (map);
+
+	return map;
 }

--- a/x86/src/KM/main.c
+++ b/x86/src/KM/main.c
@@ -1,52 +1,34 @@
-/*
- * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
- * 
- * Kmeans Benchmark Kernel.
- */
-
-#include <omp.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
+/* Kernel Include */
 #include <timer.h>
 #include <util.h>
 #include "km.h"
 
-/*
- * Problem.
- */
-struct problem
-{
+/* C And MPPA Library Includes*/
+#include <omp.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Problem. */
+struct problem {
 	int npoints;       /* Number of points.    */
-	int dimension;     /* Data dimension.      */
 	int ncentroids;    /* Number of centroids. */
-	float mindistance; /* Minimum distance.    */
 };
 
 /* Problem sizes. */
-static struct problem tiny     = {  4096, 16,  256, 0.0 };
-static struct problem small    = {  8192, 16,  512, 0.0 };
-static struct problem standard = { 16384, 16, 1024, 0.0 };
-static struct problem large    = { 32768, 16, 1024, 0.0 };
-static struct problem huge     = { 65536, 16, 1024, 0.0 };
+static struct problem tiny     = {  4096, 256};
+static struct problem small    = {  8192, 512};
+static struct problem standard = { 16384, 1024};
+static struct problem large    = { 32768, 1024};
+static struct problem huge     = { 65536, 1024};
 
-/* Be verbose? */
-int verbose = 0;
+static int seed = 0;              /* Seed number. */      
+static struct problem *p = &tiny; /* Problem. */   
+int verbose = 0;                  /* Be verbose? */            
+int nthreads = 1;                 /* Number of threads. */       
 
-/* Number of threads. */                
-int nthreads = 1;
-
-/* Seed number. */
-static int seed = 0;
-
-/* Problem. */           
-static struct problem *p = &tiny;
-
-/*
- * Prints program usage and exits.
- */
-static void usage(void)
-{
+/* Prints program usage and exits. */
+static void usage() {
 	printf("Usage: kmeans [options]\n");
 	printf("Brief: Kmeans Benchmark Kernel\n");
 	printf("Options:\n");
@@ -61,11 +43,8 @@ static void usage(void)
 	exit(0);
 }
 
-/*
- * Reads command line arguments.
- */
-static void readargs(int argc, char **argv)
-{
+/* Reads command line arguments. */
+static void readargs(int argc, char **argv) {
 	int i;     /* Loop index.       */
 	char *arg; /* Working argument. */
 	int state; /* Processing state. */
@@ -133,56 +112,54 @@ static void readargs(int argc, char **argv)
 		usage();
 }
 
-/*
- * Runs benchmark.
- */
-int main(int argc, char **argv)
-{
-	int i;          /* Loop index.      */
-	int *map;       /* Map of clusters. */
-	uint64_t end;   /* End time.        */
-	uint64_t start; /* Start time.      */
-	vector_t *data; /* Data points.     */
-	
+/* Runs benchmark. */
+int main(int argc, char **argv) {
+	int i;               /* Loop index.             */
+	int *map;            /* Map of clusters.        */
+	int dimension;       /* Problem dimension.      */
+	float *points;       /* Points being clustered. */
+	uint64_t start, end; /* Start and End time.     */
+
 #ifdef _XEON_PHI_
 	double power;
 #endif
-	
+
 	readargs(argc, argv);
-	
+
 	timer_init();
 	srandnum(seed);
 	omp_set_num_threads(nthreads);
-	
+
+	/* Setting the dimension for the problem. */
+	dimension = 16; 
+
 	/* Benchmark initialization. */
 	if (verbose)
 		printf("initializing...\n");
 	start = timer_get();
-	data = smalloc(p->npoints*sizeof(vector_t));
-	for (i = 0; i < p->npoints; i++)
-	{
-		data[i] = vector_create(p->dimension);
-		vector_random(data[i]);
-	}
+	points = smalloc(p->npoints*dimension*sizeof(float));
+	for (i = 0; i < p->npoints * dimension; i++)
+		points[i] = randnum() & 0xffff;
 	end = timer_get();
+
 	if (verbose)
 		printf("  time spent: %f\n", timer_diff(start, end)*MICROSEC);
-	
+
 #ifdef _XEON_PHI_
 	power_init();
 #endif
-	
+
 	/* Cluster data. */
 	if (verbose)
 		printf("clustering data...\n");
 	start = timer_get();
-	map = kmeans(data, p->npoints, p->ncentroids, p->mindistance);
+	map = kmeans(points, p->npoints, p->ncentroids, dimension);
 	end = timer_get();
-	
+
 #ifdef _XEON_PHI_
 	power = power_end();
 #endif
-	
+
 	printf("timing statistics:\n");
 	printf("  total time:    %f\n", timer_diff(start, end)*MICROSEC);
 
@@ -192,9 +169,8 @@ int main(int argc, char **argv)
 	
 	/* House keeping. */
 	free(map);
-	for (i = 0; i < p->npoints; i++)
-		vector_destroy(data[i]);
-	free(data);
+	free(points);
 	
 	return (0);
+
 }

--- a/x86/src/KM/vector.c
+++ b/x86/src/KM/vector.c
@@ -1,165 +1,39 @@
-/*
- * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
- * 
- * vector.c - Vector Library implementation.
- */
-
-#include <math.h>
-#include <string.h>
+/* Kernel Include */
 #include <util.h>
 #include "km.h"
 
-/*
- * Creates a vector.
- */
-struct vector *vector_create(int n)
-{
-	struct vector *v;
-	
-	v = smalloc(sizeof(struct vector));
-	
-	/* Initilize vector. */
-	v->size = n;
-	v->elements = calloc(n, sizeof(float));
+/* C And MPPA Library Includes*/
+#include <math.h>
+#include <string.h>
 
-	return (v);
+extern int dimension; /* Problem dimension. */
+
+/* Assigns a vector to another. */
+void vector_assign(float *v1, float *v2) {
+	for (int i = 0; i < dimension; i++)
+		v1[i] = v2[i];
 }
 
-/*
- * Adds two vectors.
- */
-struct vector *vector_add(struct vector *v1, const struct vector *v2)
-{
-	int i; /* Loop index.  */
-	int n; /* Vector size. */
-	
-	n = vector_size(v1);
-	
-	/* Add vectors. */
-	for (i = 0; i < n; i++)
-		VECTOR(v1, i) += VECTOR(v2, i);
-	
-	return (v1);
-}
-
-/*
- * Assigns a vector to another.
- */
-struct vector *vector_assign(struct vector *v1, const struct vector *v2)
-{
-	int i; /* Loop index.  */
-	int n; /* Vector size. */
-	
-	n = vector_size(v1);
-	
-	/* Add vectors. */
-	for (i = 0; i < n; i++)
-		VECTOR(v1, i) = VECTOR(v2, i);
-	
-	return (v1);
-}
-
-/*
- * Destroys a vector.
- */
-void vector_destroy(struct vector *v)
-{
-	free(v->elements);
-	free(v);
-}
-
-/*
- * Computes the euclidean distance between two points.
- */
-float vector_distance(const struct vector *a, const struct vector *b)
-{
-	int i;          /* Loop index. */
-	float distance; /* Distance.   */
-
-	distance = 0;
+/* Computes the euclidean distance between two points. */
+float vector_distance(float *v1, float *v2) {
+	float distance = 0;
 
 	/* Computes the euclidean distance. */
-	for (i = 0; i < a->size; i++)
-		distance +=  pow(VECTOR(a, i) - VECTOR(b, i), 2);
+	for (int i = 0; i < dimension; i++)
+		distance +=  pow(v1[i] - v2[i], 2);
 	distance = sqrt(distance);
 	
-	return (distance);
+	return distance;
 }
 
-/*
- * Tests if two vectors are equal.
- */
-int vector_equal(const struct vector *a, const struct vector *b)
-{
-	int i;
-	
-	/* Test all elements. */
-	for (i = 0; i < a->size; i++)
-	{
-		if (VECTOR(a, i) != VECTOR(b, i))
-			return (0);
-	}
-	
-	return (1);
+/* Multiplies a vector by a scalar. */
+void vector_mult(float *v, float scalar) {
+	for (int i = 0; i < dimension; i++)
+		v[i] *= scalar;
 }
 
-/*
- * Multiplies a vector by a scalar.
- */
-struct vector *vector_mult(struct vector *v, float scalar)
-{
-	int i; /* Loop index.  */
-	int n; /* Vector size. */
-	
-	n = vector_size(v);
-	
-	/* Add vectors. */
-	for (i = 0; i < n; i++)
-		VECTOR(v, i) *= scalar;
-	
-	return (v);
+/* Adds two vectors. */
+void vector_add(float *v1, float *v2) {
+	for (int i = 0; i < dimension; i++)
+		v1[i] += v2[i];
 }
-
-/*
- * Fills up vector with random numbers.
- */
-struct vector *vector_random(struct vector *v)
-{
-	int i;
-	
-	/* Fill vector. */
-	for (i = 0; i < vector_size(v); i++)
-		VECTOR(v, i) = randnum() & 0xffff;
-
-	return (v);
-}
-
-/*
- * Subtracts two vectors.
- */
-struct vector *vector_sub(struct vector *v1,const struct vector *v2)
-{
-	int i; /* Loop index.  */
-	int n; /* Vector size. */
-	
-	/* Invalid argument. */
-	if (vector_size(v1) != vector_size(v2))
-		return (NULL);
-	
-	n = vector_size(v1);
-	
-	/* Subtract vectors. */
-	for (i = 0; i < n; i++)
-		VECTOR(v1, i) -= VECTOR(v2, i);
-	
-	return (v1);
-}
-
-/*
- * Clears a vector.
- */
-void vector_clear(struct vector *v)
-{
-	memset(v->elements, 0, sizeof(float)*vector_size(v));	
-}
-


### PR DESCRIPTION
While porting the KM kernel on the mppa-256 platform, some bugs were found. Those bugs  are present in the x86 implementation of the kernel too, contributing to a slow execution of the kernel. So, for purpose of optimization, I updated the kernel on x86 so I could have the logic ready. Some of the optimizations are: Pointers "dirty" and "has_changed" are redundant, whereas in the new implementation we only use "has_changed" to check if we need a new iteration. In the new implementation, on function compute_centroids, we only iterate throught "npoints" + "ncentroids", whereas in the old one we would have to iterate, at most, "npoints" * "ncentroids". There's no check to see if a cluster is dirty in this function anymore. We are always recalculating the centroids and only after the function returns that we see if we need another iteration by checking the "has_changed" pointer, which were changed (if any point changed cluster) in "populate" function. Pointer too_far has no meaning within the standard km implementation and results without it were in the same range, so I removed it. To finish, now all centroids and all points are grouped within a one-dimensional array, one for the centroids and one for the points. Those arrays are divided based on the dimension that we are working. So if we are working with a 16 dimension, those arrays would have all 16 coordinates of the first point , for example, starting from array[0] up until array[15], and so on. 
