### PR TITLE
MPPA-256 Lib Async FAST Kernel

### DIFF
--- a/mppa256/async/include/problem.h
+++ b/mppa256/async/include/problem.h
@@ -50,6 +50,15 @@ struct problem {
 	int imgsize;  /* Image size. */
 };
 
+#elif _FAST_
+
+struct problem{
+	int maskcolumns; /* Mask columns. */
+	int maskrows;    /* Mask Rows.    */
+	int masksize;	 /* Mask Size.    */
+	int imgsize;  	 /* Image size.   */
+};
+
 #endif /* Benchmarks */
 
 #endif /* _MASTER_ */

--- a/mppa256/async/src/FAST/kernel.h
+++ b/mppa256/async/src/FAST/kernel.h
@@ -1,0 +1,26 @@
+#ifndef _KERNEL_H_
+#define _KERNEL_H_
+
+	/* Maximum thread num per cluster. */
+	#define MAX_THREADS (16)
+	
+	/* Maximum chunk size. */
+	#define CHUNK_SIZE (512)
+	
+	/* Maximum mask size. */
+	#define MASK_SIZE (54)
+	
+	/* Mask radius. */
+	#define MASK_RADIUS (3)
+	
+	/* Maximum image size. */
+	#define IMG_SIZE (24576)
+	
+	/* Threshold value between central pixel and neighboor pixel. */
+	#define THRESHOLD (20)
+	
+	/* Type of messages. */
+	#define MSG_CHUNK 1
+	#define MSG_DIE   0
+
+#endif /* _KERNEL_H_ */

--- a/mppa256/async/src/FAST/kernel.h
+++ b/mppa256/async/src/FAST/kernel.h
@@ -7,6 +7,9 @@
 	/* Maximum chunk size. */
 	#define CHUNK_SIZE (512)
 	
+	/* Chunk size * Chunk size. */
+	#define CHUNK_SIZE_SQRD (262144)
+	
 	/* Maximum mask size. */
 	#define MASK_SIZE (54)
 	
@@ -20,7 +23,7 @@
 	#define THRESHOLD (20)
 	
 	/* Type of messages. */
-	#define MSG_CHUNK 1
-	#define MSG_DIE   0
+	#define MSG_CHUNK 2
+	#define MSG_DIE   1
 
 #endif /* _KERNEL_H_ */

--- a/mppa256/async/src/FAST/makefile
+++ b/mppa256/async/src/FAST/makefile
@@ -1,0 +1,28 @@
+# Executable.
+EXEC = fast
+
+# Use bare libraries
+system-name := bare
+
+# Compilation flags.
+cflags := -fopenmp -O3 -std=gnu99 -g -mhypervisor -I $(INCDIR) -Wall -Wextra -Winit-self -Wswitch-default -Wshadow -Wuninitialized
+MPPAFlags := -g -lvbsp -lutask -lgomp -lmppa_remote -lmppa_async -lmppa_request_engine -lmppapower -lmppanoc -lmpparouting -mhypervisor
+
+# Builds master binary.
+io-bin := io_bin
+io_bin-cflags := -D_MASTER_ -D_FAST_
+io_bin-lflags := $(MPPAFlags) -lpcie_queue -lm
+io_bin-srcs := $(wildcard master/*.c) $(wildcard $(LIBSRCDIR)/*.c) 
+
+# Builds slave binary.
+cluster-bin := cluster_bin
+cluster-lflags := $(MPPAFlags) -lm
+cluster_bin-srcs := $(wildcard slave/*.c) $(wildcard $(LIBSRCDIR)/*.c)
+
+# Builds image (master + slave)
+mppa-bin := multibin_bin
+multibin_bin-objs := io_bin cluster_bin
+multibin_bin-name := $(EXEC).img
+
+# must be at the end of the makefile!
+include $(K1_TOOLCHAIN_DIR)/share/make/Makefile.kalray

--- a/mppa256/async/src/FAST/master/main.c
+++ b/mppa256/async/src/FAST/master/main.c
@@ -1,0 +1,181 @@
+/* Kernel Includes */
+#include <problem.h>
+#include <global.h>
+#include <timer.h>
+#include <util.h>
+#include "../kernel.h"
+
+/* C And MPPA Library Includes*/
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* FAST corner detection. */
+extern int fast (char *img, char *output,int imgsize, int *mask, int masksize);
+
+/* Problem initials and FullName */
+char *bench_initials = "FAST";
+char *bench_fullName = "Features from accelerated segment test";
+
+/* Timing statistics. */
+uint64_t master = 0;          /* Time spent on master.        */
+uint64_t spawn = 0;           /* Time spent spawning slaves   */
+uint64_t slave[NUM_CLUSTERS]; /* Time spent on slaves.        */
+uint64_t communication = 0;   /* Time spent on communication. */
+uint64_t total = 0;           /* Total time.                  */
+
+/* Data exchange statistics. */
+size_t data_put = 0; /* Number of bytes put.    */
+unsigned nput = 0;   /* Number of bytes gotten. */
+size_t data_get = 0; /* Number of items put.    */
+unsigned nget = 0;   /* Number of items gotten. */
+
+/* Problem sizes. */
+struct problem tiny     = {2,27,54,2048};
+struct problem small    = {2,27,54,4096};
+struct problem standard = {2,27,54,8192};
+struct problem large    = {2,27,54,16384};
+struct problem huge     = {2,27,54,24576};
+
+/* Benchmark parameters. */
+int verbose = 0;                  /* Be verbose?        */
+int nclusters = 1;                /* Number of threads. */
+static int seed = 0;              /* Seed number.       */
+struct problem *prob = &tiny; /* Problem.           */
+
+/* Generates mask. */
+static void generate_mask(int *mask) {
+	mask[0*prob->maskcolumns + 0] = -1;
+	mask[0*prob->maskcolumns + 1] = -3;
+
+	mask[1*prob->maskcolumns + 0] = 0;
+	mask[1*prob->maskcolumns + 1] = -3;
+
+	mask[2*prob->maskcolumns + 0] = 1;
+	mask[2*prob->maskcolumns + 1] = -3;
+	
+	mask[3*prob->maskcolumns + 0] = 2;
+	mask[3*prob->maskcolumns + 1] = -2;
+
+	mask[4*prob->maskcolumns + 0] = 3;
+	mask[4*prob->maskcolumns + 1] = -1;
+
+	mask[5*prob->maskcolumns + 0] = 3;
+	mask[5*prob->maskcolumns + 1] = 0;
+
+	mask[6*prob->maskcolumns + 0] = 3;
+	mask[6*prob->maskcolumns + 1] = 1;
+
+	mask[7*prob->maskcolumns + 0] = 2;
+	mask[7*prob->maskcolumns + 1] = 2;
+
+	mask[8*prob->maskcolumns + 0] = 1;
+	mask[8*prob->maskcolumns + 1] = 3;
+
+	mask[9*prob->maskcolumns + 0] = 0;
+	mask[9*prob->maskcolumns + 1] = 3;
+
+	mask[10*prob->maskcolumns + 0] = -1;
+	mask[10*prob->maskcolumns + 1] = 3;
+
+	mask[11*prob->maskcolumns + 0] = -2;
+	mask[11*prob->maskcolumns + 1] = 2;
+
+	mask[12*prob->maskcolumns + 0] = -3;
+	mask[12*prob->maskcolumns + 1] = 1;
+
+	mask[13*prob->maskcolumns + 0] = -3;
+	mask[13*prob->maskcolumns + 1] = 0;
+
+	mask[14*prob->maskcolumns + 0] = -3;
+	mask[14*prob->maskcolumns + 1] = -1;
+
+	mask[15*prob->maskcolumns + 0] = -2;
+	mask[15*prob->maskcolumns + 1] = -2;
+
+	mask[16*prob->maskcolumns + 0] = -1;
+	mask[16*prob->maskcolumns + 1] = -3;
+
+	mask[17*prob->maskcolumns + 0] = 0;
+	mask[17*prob->maskcolumns + 1] = -3;
+
+	mask[18*prob->maskcolumns + 0] = 1;
+	mask[18*prob->maskcolumns + 1] = -3;
+	
+	mask[19*prob->maskcolumns + 0] = 2;
+	mask[19*prob->maskcolumns + 1] = -2;
+
+	mask[20*prob->maskcolumns + 0] = 3;
+	mask[20*prob->maskcolumns + 1] = -1;
+
+	mask[21*prob->maskcolumns + 0] = 3;
+	mask[21*prob->maskcolumns + 1] = 0;
+
+	mask[22*prob->maskcolumns + 0] = 3;
+	mask[22*prob->maskcolumns + 1] = 1;
+
+	mask[23*prob->maskcolumns + 0] = 2;
+	mask[23*prob->maskcolumns + 1] = 2;
+	
+	mask[24*prob->maskcolumns + 0] = 1;
+	mask[24*prob->maskcolumns + 1] = 3;
+
+	mask[25*prob->maskcolumns + 0] = 0;
+	mask[25*prob->maskcolumns + 1] = 3;
+
+	mask[26*prob->maskcolumns + 0] = -1;
+	mask[26*prob->maskcolumns + 1] = 3;
+}
+
+/* Runs benchmark. */
+int main(int argc, char **argv) {
+	int *mask;      	 /* Mask.                  */
+	char *img; 			 /* Image input.           */
+	char *output;		 /* Image output.		   */
+	int numcorners=0;	 /* Total corners detected */
+	uint64_t start, end; /* Start & End times.     */
+
+	readargs(argc, argv);
+	timer_init();
+	srandnum(seed);
+	
+	/* Benchmark initialization. */
+	if (verbose)
+		printf("initializing...\n");
+
+	start = timer_get();
+	img = smalloc(prob->imgsize*prob->imgsize*sizeof(char));
+	output = scalloc(prob->imgsize*prob->imgsize,sizeof(char));
+
+	for (int i = 0; i < prob->imgsize*prob->imgsize; i++){
+		char val = (char) (randnum() & 0xff);
+		img[i] = (val>0) ? val : val*(-1);
+	}
+
+	mask = smalloc(prob->maskrows*prob->maskcolumns*sizeof(int));
+	generate_mask(mask);
+	end = timer_get();
+
+	if (verbose)
+		printf("  time spent: %f\n", timer_diff(start, end)*MICROSEC);
+		
+	/* Apply filter. */
+	if (verbose)
+		printf("Detecting corners...\n");
+
+	start = timer_get();
+	numcorners = fast(img, output, prob->imgsize, mask, prob->masksize);
+	end = timer_get();
+	
+	total = timer_diff(start, end);
+
+	inform_statistics();
+	
+	/* House keeping. */
+	free(mask);
+	free(img);
+	free(output);
+	
+	return (0);
+}

--- a/mppa256/async/src/FAST/master/main.c
+++ b/mppa256/async/src/FAST/master/main.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
 	int *mask;      	 /* Mask.                  */
 	char *img; 			 /* Image input.           */
 	char *output;		 /* Image output.		   */
-	int numcorners=0;	 /* Total corners detected */
+	int numcorners = 0;	 /* Total corners detected */
 	uint64_t start, end; /* Start & End times.     */
 
 	readargs(argc, argv);
@@ -171,6 +171,7 @@ int main(int argc, char **argv) {
 	total = timer_diff(start, end);
 
 	inform_statistics();
+	printf("Summ. of corners = %d\n", numcorners);
 	
 	/* House keeping. */
 	free(mask);

--- a/mppa256/async/src/FAST/master/main.c
+++ b/mppa256/async/src/FAST/master/main.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
 	total = timer_diff(start, end);
 
 	inform_statistics();
-	printf("Summ. of corners = %d\n", numcorners);
+	printf("Sum. of corners = %d\n", numcorners);
 	
 	/* House keeping. */
 	free(mask);

--- a/mppa256/async/src/FAST/master/master.c
+++ b/mppa256/async/src/FAST/master/master.c
@@ -1,0 +1,125 @@
+/* Kernel Includes */
+#include <async_util.h>
+#include <global.h>
+#include <timer.h>
+#include <util.h>
+#include "../kernel.h"
+
+/* C And MPPA Library Includes*/
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+
+/* Data exchange segments. */
+static mppa_async_segment_t infos_seg;
+static mppa_async_segment_t mask_seg;
+static mppa_async_segment_t img_seg;
+static mppa_async_segment_t output_seg;
+
+/* Kernel variables. */
+static char *img;          /* Input image.                     */
+static char *output;       /* Output image.                    */ 
+static int imgsize;        /* Dimension of image.              */
+static int *mask;          /* Mask.                            */
+static int masksize;       /* Dimension of mask.               */
+static int numcorners = 0; /* Sum. of cornes.                  */
+static int offset;         /* Intersection between two chunks. */
+static int nchunks;        /* Nº of chunks to be processed.    */
+
+/* Timing auxiliars */
+static uint64_t start, end;
+
+/* Statistics information from slaves. */
+static struct message statistics[NUM_CLUSTERS];
+
+/* Create segments for data and info exchange. */
+static void create_segments() {
+	createSegment(&signals_offset_seg, SIG_SEG_0, &sig_offsets, nclusters * sizeof(off64_t), 0, 0, NULL);
+	createSegment(&infos_seg, MSG_SEG_0, &statistics, nclusters * sizeof(struct message), 0, 0, NULL);
+	createSegment(&mask_seg, 5, mask, masksize * sizeof(int), 0, 0, NULL);
+	createSegment(&img_seg, 6, img, imgsize * imgsize * sizeof(char), 0, 0, NULL);
+	createSegment(&output_seg, 7, output, imgsize * imgsize * sizeof(char), 0, 0, NULL);
+}
+
+
+static void spawnSlaves() {
+	start = timer_get();
+
+	char str_masksize[10], str_offset[10], str_nchunks[10], str_nclusters[10];
+	sprintf(str_masksize, "%d", masksize);
+	sprintf(str_offset, "%d", offset);
+	sprintf(str_nchunks, "%d", nchunks);
+	sprintf(str_nclusters, "%d", nclusters);
+
+	set_cc_signals_offset();
+
+	/* Parallel spawning PE0 of cluster "i" */
+	#pragma omp parallel for default(shared) num_threads(3)
+	for (int i = 0; i < nclusters; i++) {
+		char *args[6];
+		args[0] = str_masksize;
+		args[1] = str_offset;
+		args[2] = str_nchunks;
+		args[3] = str_nclusters;
+		args[4] = str_cc_signals_offset[i];
+		args[5] = NULL;
+
+		spawn_slave(i, args);
+	}
+	end = timer_get();
+	spawn = timer_diff(start, end);
+}
+
+/*
+ * FAST corner detection.
+ */
+int fast(char *_img, char *_output, int _imgsize, int *_mask, int _masksize) {	
+	img = _img;
+	output = _output;
+	imgsize = _imgsize;
+	mask = _mask;
+	masksize = _masksize;
+
+	offset = (imgsize/CHUNK_SIZE)*MASK_RADIUS; 
+	nchunks = (imgsize*imgsize)/(CHUNK_SIZE*CHUNK_SIZE);
+
+	/* Initializes async server */
+	async_master_start();
+
+	/* Creates all necessary segments for data exchange */
+	create_segments();
+
+	/* Spawns all clusters. */
+	spawnSlaves();
+
+	/* Synchronize variable offsets between Master and Slaves. */
+	get_slaves_signals_offset();
+
+	/* Waiting for clusters answers. */
+	for (int i = 0; i < nclusters; i++) {
+		waitCondition(&cluster_signals[i], 0, MPPA_ASYNC_COND_GT, NULL);
+
+		numcorners += cluster_signals[i];
+		cluster_signals[i] = 0;
+		
+		/* Synchronization. */
+		send_signal(i);
+	}
+
+	/* Wait all slaves statistics info. */
+	wait_statistics();
+
+	/* Set slaves statistics. */
+	set_statistics(statistics);
+
+	/* Waiting for PE0 of each cluster to end */
+	join_slaves();
+
+	/* Finalizes async server */
+	async_master_finalize();
+	
+	return numcorners;
+}

--- a/mppa256/async/src/FAST/slave/slave.c
+++ b/mppa256/async/src/FAST/slave/slave.c
@@ -10,12 +10,23 @@
 #include <stdio.h>
 #include <string.h>
 
+/* Asynchronous segments */
+static mppa_async_segment_t infos_seg;
+static mppa_async_segment_t mask_seg;
+static mppa_async_segment_t img_seg;
+static mppa_async_segment_t output_seg;
+
 /* FAST parameters. */
 static int masksize;
-static int mask[MASK_SIZE];
-static char chunk[(CHUNK_SIZE*CHUNK_SIZE)+IMG_SIZE*MASK_RADIUS];
+static int *mask;
+static char *chunk;
 static int corners[MAX_THREADS];
-static int output[CHUNK_SIZE*CHUNK_SIZE];
+static int output[CHUNK_SIZE_SQRD];
+static int corners_summ;
+
+/* From master. */
+static int aux_offset;
+static int nchunks;       
 
 /* Timing statistics auxiliars. */
 static uint64_t start, end;
@@ -28,8 +39,116 @@ size_t data_get = 0;         /* Number of bytes gotten. */
 unsigned nput = 0;           /* Number of put ops.      */
 unsigned nget = 0;           /* Number of get ops.      */
 
-/* Compute Cluster ID */
+/* Compute Cluster ID & num. of clusters being used. */
 int cid;
+int nclusters;
+
+static void clone_segments() {
+	cloneSegment(&signals_offset_seg, SIG_SEG_0, 0, 0, NULL);
+	cloneSegment(&infos_seg, MSG_SEG_0, 0, 0, NULL);
+	cloneSegment(&mask_seg, 5, 0, 0, NULL);
+	cloneSegment(&img_seg, 6, 0, 0, NULL);
+	cloneSegment(&output_seg, 7, 0, 0, NULL);
+}
+
+/* FAST corner detection. */
+void fast(int offset, int n) {
+	int i,j,r,z,x,y;
+	char accumBrighter, accumDarker;
+	char imagePixel,centralPixel;
+	
+	#pragma omp parallel default(shared) private(imagePixel,centralPixel,i,j,z,r,x,y,accumBrighter,accumDarker)
+	{
+		#pragma omp for
+		for (j = offset; j<CHUNK_SIZE+offset; j++){
+			for (i = 0; i<CHUNK_SIZE; i++){
+				centralPixel = chunk[j*CHUNK_SIZE + i];
+				
+				z = 0;
+				while(z<16){
+					accumBrighter = 0;
+					accumDarker = 0;
+					for(r = 0;r<12;r++){
+						x = i + mask[((r+z) * 2) + 0];
+						y = j + mask[((r+z) * 2) + 1];
+						
+						if (x >= 0 && y>=0 && ((y*CHUNK_SIZE + x) < n)){
+							imagePixel = chunk[y * (CHUNK_SIZE) + x];
+							if(imagePixel >= (centralPixel+THRESHOLD) ){
+								if( accumBrighter == 0){
+									accumDarker++;
+								}
+								else{ //Sequence is not contiguous
+									z += r - 1;
+									goto not_a_corner;
+								}
+							}
+							else if (imagePixel<=(centralPixel-THRESHOLD) ){
+								if (accumDarker == 0){
+									accumBrighter++;
+								}
+								else{ //Sequence is not contiguous
+									z += r - 1;
+									goto not_a_corner;
+								}
+							}
+							else{ //Actual pixel is inside threshold interval 
+								z += r;								
+								goto not_a_corner;
+							}
+						}
+					}
+					if(accumBrighter == 12 || accumDarker == 12){
+						corners[omp_get_thread_num()]++;
+						output[(j-offset)*CHUNK_SIZE + i] = 1;
+						z = 16;
+					}
+not_a_corner:				z++;			
+				}
+			}
+		}
+	}
+}
+
+/* Process chunks. */
+static void process_chuncks() {
+	/* Auxiliary variables. */
+	int chunk_start = 0;
+	int chunk_size;
+	int output_start;
+
+	corners_summ = 0; 
+
+	dataGet(mask, &mask_seg, 0, masksize, sizeof(int), NULL);
+
+	for (int nchunk = cid; nchunk < nchunks; nchunk += nclusters) {
+		if (nchunk > 0)
+			chunk_start = (nchunk * CHUNK_SIZE_SQRD) - (aux_offset * CHUNK_SIZE);
+
+		if (nchunk == nchunks - 1)
+			chunk_size = CHUNK_SIZE_SQRD + (aux_offset * CHUNK_SIZE);
+		else
+			chunk_size = CHUNK_SIZE_SQRD + (2 * aux_offset * CHUNK_SIZE);
+
+		dataGet(chunk, &img_seg, chunk_start, chunk_size, sizeof(char), NULL);
+
+		memset(corners,0,MAX_THREADS*sizeof(int));
+		memset(output,0,CHUNK_SIZE_SQRD*sizeof(char));
+
+		start = timer_get();
+		(nchunk == 0) ? fast(0, chunk_size) : fast(aux_offset, chunk_size);
+		end = timer_get();
+		total += timer_diff(start, end);
+
+		for (int i = 0; i < MAX_THREADS; i++)
+			corners_summ += corners[i];
+
+		output_start = nchunk  * CHUNK_SIZE_SQRD;
+			
+		/* Sending back results. */
+		dataPut(output, &output_seg, output_start, CHUNK_SIZE_SQRD, sizeof(char), NULL);
+	}
+}
 
 int main(__attribute__((unused))int argc, char **argv) {
 	/* Initializes async client */
@@ -40,9 +159,39 @@ int main(__attribute__((unused))int argc, char **argv) {
 
 	/* Util information for the problem. */
 	cid = __k1_get_cluster_id();
+	masksize = atoi(argv[0]);
+	aux_offset = atoi(argv[1]);
+	nchunks = atoi(argv[2]);
+	nclusters = atoi(argv[3]);
+	sigback_offset = (off64_t) atoll(argv[4]);
+
+	mask = (int *) smalloc(masksize * sizeof(int));
+	chunk = (char *) smalloc(CHUNK_SIZE_SQRD + (2* aux_offset + CHUNK_SIZE_SQRD));
+
+	/* Clones message exchange and io_signal segments */
+	clone_segments();
+
+	/* Send io_signal offset to IO. */
+	send_sig_offset();
+
+	/* Processing the chuncks. */
+	process_chuncks();
+
+	/* Send back partial summ of corners */
+	poke(MPPA_ASYNC_DDR_0, sigback_offset, (long long) corners_summ);
+
+	/* Synchronization. */
+	wait_signal();
+
+	/* Put statistics in stats. segment on IO side. */
+	send_statistics(&infos_seg);
 
 	/* Finalizes async library and rpc client */
 	async_slave_finalize();
+
+	/* House keeping. */
+	free(mask);
+	free(chunk);
 	
 	return 0;
 }

--- a/mppa256/async/src/FAST/slave/slave.c
+++ b/mppa256/async/src/FAST/slave/slave.c
@@ -22,7 +22,7 @@ static int *mask;
 static char *chunk;
 static int corners[MAX_THREADS];
 static int output[CHUNK_SIZE_SQRD];
-static int corners_summ;
+static int corners_sum;
 
 /* From master. */
 static int aux_offset;
@@ -117,7 +117,7 @@ static void process_chuncks() {
 	int chunk_size;
 	int output_start;
 
-	corners_summ = 0; 
+	corners_sum = 0; 
 
 	dataGet(mask, &mask_seg, 0, masksize, sizeof(int), NULL);
 
@@ -141,7 +141,7 @@ static void process_chuncks() {
 		total += timer_diff(start, end);
 
 		for (int i = 0; i < MAX_THREADS; i++)
-			corners_summ += corners[i];
+			corners_sum += corners[i];
 
 		output_start = nchunk  * CHUNK_SIZE_SQRD;
 			
@@ -177,8 +177,8 @@ int main(__attribute__((unused))int argc, char **argv) {
 	/* Processing the chuncks. */
 	process_chuncks();
 
-	/* Send back partial summ of corners */
-	poke(MPPA_ASYNC_DDR_0, sigback_offset, (long long) corners_summ);
+	/* Send back partial sum of corners */
+	poke(MPPA_ASYNC_DDR_0, sigback_offset, (long long) corners_sum);
 
 	/* Synchronization. */
 	wait_signal();

--- a/mppa256/async/src/FAST/slave/slave.c
+++ b/mppa256/async/src/FAST/slave/slave.c
@@ -1,0 +1,48 @@
+/* Kernel Includes */
+#include <async_util.h>
+#include <global.h>
+#include <timer.h>
+#include <util.h>
+#include "../kernel.h"
+
+/* C And MPPA Library Includes*/
+#include <omp.h>
+#include <stdio.h>
+#include <string.h>
+
+/* FAST parameters. */
+static int masksize;
+static int mask[MASK_SIZE];
+static char chunk[(CHUNK_SIZE*CHUNK_SIZE)+IMG_SIZE*MASK_RADIUS];
+static int corners[MAX_THREADS];
+static int output[CHUNK_SIZE*CHUNK_SIZE];
+
+/* Timing statistics auxiliars. */
+static uint64_t start, end;
+
+/* Individual Slave statistics. */
+uint64_t total = 0;          /* Time spent on slave.    */
+uint64_t communication = 0;  /* Time spent on comms.    */               
+size_t data_put = 0;         /* Number of bytes put.    */
+size_t data_get = 0;         /* Number of bytes gotten. */
+unsigned nput = 0;           /* Number of put ops.      */
+unsigned nget = 0;           /* Number of get ops.      */
+
+/* Compute Cluster ID */
+int cid;
+
+int main(__attribute__((unused))int argc, char **argv) {
+	/* Initializes async client */
+	async_slave_init();
+
+	/* Timer synchronization */
+	timer_init();
+
+	/* Util information for the problem. */
+	cid = __k1_get_cluster_id();
+
+	/* Finalizes async library and rpc client */
+	async_slave_finalize();
+	
+	return 0;
+}

--- a/mppa256/async/src/GF/master/master.c
+++ b/mppa256/async/src/GF/master/master.c
@@ -14,7 +14,6 @@
 static mppa_async_segment_t infos_seg;
 static mppa_async_segment_t mask_seg;
 static mppa_async_segment_t chunks_seg;
-static mppa_async_segment_t newimg_seg;
 
 /* Gaussian Filter. */
 static unsigned char *img;       /* Input image.                    */
@@ -23,7 +22,7 @@ static int imgsize;              /* Dimension of image.             */
 static double *mask;             /* Mask.                           */
 static int masksize;             /* Dimension of mask.              */
 static int chunk_with_halo_size; /* Chunk size including a halo.    */
-static unsigned char *chunk;     /* chunks of an image per cluster. */
+static unsigned char *chunk;     /* chunk to be sent to clusters X. */
 
 /* Workaround of the memory leak with the "huge" class. */
 static unsigned int is_class_huge = 0;    /* Class of execution = "huge"?    */
@@ -40,7 +39,6 @@ static void create_segments() {
 	createSegment(&infos_seg, MSG_SEG_0, &statistics, nclusters * sizeof(struct message), 0, 0, NULL);
 	createSegment(&mask_seg, 5, mask, masksize * masksize * sizeof(double), 0, 0, NULL);
 	createSegment(&chunks_seg, 6, chunk, chunk_with_halo_size * chunk_with_halo_size * sizeof(unsigned char), 0, 0, NULL);
-	createSegment(&newimg_seg, 7, newimg, imgsize * imgsize * sizeof(unsigned char), 0, 0, NULL);
 }
 
 static void spawnSlaves() {

--- a/mppa256/async/src/GF/slave/slave.c
+++ b/mppa256/async/src/GF/slave/slave.c
@@ -16,13 +16,12 @@
 static mppa_async_segment_t infos_seg;
 static mppa_async_segment_t mask_seg;
 static mppa_async_segment_t chunks_seg;
-static mppa_async_segment_t newimg_seg;
 
 /* Kernel parameters. */
-static int masksize;                                   /* Mask dimension.              */
-static int chunk_with_halo_size;     	               /* Chunk size including a halo. */
-static double *mask;                                   /* Mask.                        */
-static unsigned char *chunk;                           /* Image input chunk.           */
+static int masksize;                             /* Mask dimension.              */
+static int chunk_with_halo_size;     	         /* Chunk size including a halo. */
+static double *mask;                             /* Mask.                        */
+static unsigned char *chunk;                     /* Image input chunk.           */
 static unsigned char newchunk[CHUNK_SIZE_SQRD];  /* Image output chunk.          */
 
 /* Timing statistics auxiliars. */
@@ -44,7 +43,6 @@ static void clone_segments() {
 	cloneSegment(&infos_seg, MSG_SEG_0, 0, 0, NULL);
 	cloneSegment(&mask_seg, 5, 0, 0, NULL);
 	cloneSegment(&chunks_seg, 6, 0, 0, NULL);
-	cloneSegment(&newimg_seg, 7, 0, 0, NULL);
 }
 
 /* Gaussian filter. */

--- a/mppa256/async/src/makefile
+++ b/mppa256/async/src/makefile
@@ -3,7 +3,7 @@
 #
 
 # Builds all kernels.
-all: gf km lu fn
+all: fast #gf km lu fn
 
 # Builds FN kernel.
 fn:
@@ -25,10 +25,16 @@ gf:
 	cd GF && $(MAKE) all
 	cp GF/output/bin/*.img $(BINDIR)
 
+# Builds FAST kernel
+fast:
+	cd FAST && $(MAKE) all
+	cp FAST/output/bin/*.img $(BINDIR)
+
 # Cleans compilation files.
 clean:
 	cd FN && $(MAKE) clean
 	cd KM && $(MAKE) clean
 	cd LU && $(MAKE) clean
 	cd GF && $(MAKE) clean
+	cd FAST && $(MAKE) clean
 	rm -f $(BINDIR)/*.img

--- a/mppa256/async/src/makefile
+++ b/mppa256/async/src/makefile
@@ -3,7 +3,7 @@
 #
 
 # Builds all kernels.
-all: fast #gf km lu fn
+all: fast gf km lu fn
 
 # Builds FN kernel.
 fn:

--- a/scripts/run-mppa.sh
+++ b/scripts/run-mppa.sh
@@ -6,9 +6,12 @@
 export BINDIR=bin
 export K1DIR=/usr/local/k1tools/bin
 
+echo Inform class size and number of clusters:
+read classize nclusters
+
 # Default Parameters.
-export CLASS=tiny
-export NPROCS=4
+export CLASS=$classize
+export NPROCS=$nclusters
 
 echo "Problem size = $CLASS"
 

--- a/scripts/run-mppa.sh
+++ b/scripts/run-mppa.sh
@@ -7,12 +7,12 @@ export BINDIR=bin
 export K1DIR=/usr/local/k1tools/bin
 
 # Default Parameters.
-export CLASS=tiny	
+export CLASS=tiny
 export NPROCS=4
 
 echo "Problem size = $CLASS"
 
-for kernel in gf #km lu fn;
+for kernel in fast #gf km lu fn;
 do
 	echo "  ========== Running $kernel kernel"
 	$K1DIR/k1-jtag-runner                               \


### PR DESCRIPTION
New version of FAST kernel using the async library provided by Kalray for the MPPA-256. Some changes in the implementation were made. I've changed the chunk array size on slave side, where in the older version it was smaller then the necessary (when using class large or huge, for example, I was having seg. fault because the chunk size passed from I/O to CC's was larger than the chunk array (allocated statically)). Now this array is allocated dynamically and it has the proper size to deal with chunks. Also, communications between I/O and slaves were simplified, where, after spawning slaves, they already know the number of operations they've to do, using a "for" until some value, instead of a while(1) as it was in the older version. This way, I/O just have to wait the final answer containing all partial sums of slaves, instead of sending synchronization signals each time in a loop. I/O passes all needed information while spawning slaves (via args), and then, after they're spawned, all clusters know what to do and where to get and put data in each segment, based on those information, so there's no need for further communications (only for partial sum and timing statistics return).