### PR TITLE
MPPA-256 Lib Async IS Kernel

### DIFF
--- a/mppa256/async/include/problem.h
+++ b/mppa256/async/include/problem.h
@@ -59,6 +59,12 @@ struct problem{
 	int imgsize;  	 /* Image size.   */
 };
 
+#elif _IS_
+
+struct problem {
+	int n; /* Number of elements. */
+};
+
 #endif /* Benchmarks */
 
 #endif /* _MASTER_ */

--- a/mppa256/async/src/FAST/master/main.c
+++ b/mppa256/async/src/FAST/master/main.c
@@ -39,9 +39,9 @@ struct problem large    = {2,27,54,16384};
 struct problem huge     = {2,27,54,24576};
 
 /* Benchmark parameters. */
-int verbose = 0;                  /* Be verbose?        */
-int nclusters = 1;                /* Number of threads. */
-static int seed = 0;              /* Seed number.       */
+int verbose = 0;              /* Be verbose?        */
+int nclusters = 1;            /* Number of threads. */
+static int seed = 0;          /* Seed number.       */
 struct problem *prob = &tiny; /* Problem.           */
 
 /* Generates mask. */

--- a/mppa256/async/src/IS/makefile
+++ b/mppa256/async/src/IS/makefile
@@ -1,0 +1,28 @@
+# Executable.
+EXEC = is
+
+# Use bare libraries
+system-name := bare
+
+# Compilation flags.
+cflags := -fopenmp -O3 -std=gnu99 -g -mhypervisor -I $(INCDIR) -Wall -Wextra -Winit-self -Wswitch-default -Wshadow -Wuninitialized
+MPPAFlags := -g -lvbsp -lutask -lgomp -lmppa_remote -lmppa_async -lmppa_request_engine -lmppapower -lmppanoc -lmpparouting -mhypervisor
+
+# Builds master binary.
+io-bin := io_bin
+io_bin-cflags := -D_MASTER_ -D_IS_
+io_bin-lflags := $(MPPAFlags) -lpcie_queue -lm
+io_bin-srcs := $(wildcard master/*.c) $(wildcard $(LIBSRCDIR)/*.c) 
+
+# Builds slave binary.
+cluster-bin := cluster_bin
+cluster-lflags := $(MPPAFlags) -lm
+cluster_bin-srcs := $(wildcard slave/*.c) $(wildcard $(LIBSRCDIR)/*.c)
+
+# Builds image (master + slave)
+mppa-bin := multibin_bin
+multibin_bin-objs := io_bin cluster_bin
+multibin_bin-name := $(EXEC).img
+
+# must be at the end of the makefile!
+include $(K1_TOOLCHAIN_DIR)/share/make/Makefile.kalray

--- a/mppa256/async/src/IS/master/bucket.c
+++ b/mppa256/async/src/IS/master/bucket.c
@@ -1,98 +1,122 @@
-/*
- * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
- * 
- * bucket.c - Bucket library implementation.
- */
-
 /* Kernel Includes */
 #include <util.h>
 #include "master.h"
 
 /* C And MPPA Library Includes*/
 #include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
 
-/* Creates a bucket. */
-struct bucket *bucket_create(void) {
-	struct bucket *b;
-	
-	b = smalloc(sizeof(struct bucket));
-	
-	/* Initialize bucket. */
-	b->size = 0;
-	b->head = NULL;
-	
-	return (b);
+/*
+ * Creates a bucket.
+ */
+struct bucket *bucket_create(void)
+{
+    struct bucket *b;
+
+    b = smalloc(sizeof(struct bucket));
+
+    /* Initialize bucket. */
+    b->size = 0;
+    b->head = NULL;
+
+    return (b);
 }
 
-/* Destroys a bucket. */
-void bucket_destroy(struct bucket *b) {
-	struct minibucket *minib;
-	
-	/* Destroy mini-buckets. */
-	while (b->head != NULL) {
-		minib = b->head;
-		b->head = minib->next;
-		minibucket_destroy(minib);
-	}
-	
-	free(b);
+/*
+ * Destroys a bucket.
+ */
+void bucket_destroy(struct bucket *b)
+{
+    struct minibucket *minib;
+
+    /* Destroy mini-buckets. */
+    while (b->head != NULL)
+    {
+        minib = b->head;
+        b->head = minib->next;
+        minibucket_destroy(minib);
+    }
+
+    free(b);
 }
 
-/* Merges a bucket. */
-void bucket_merge(struct bucket *b, int *array) {
-	int i;                  /* Loop index.          */
-	struct minibucket *w;   /* Working mini-bucket. */
-	struct minibucket *min; /* Min mini-bucket.     */
-	
-	/* Merge buckets. */
-	for (i = 0;  i < b->size; i++, array++) {
-		min = b->head;
-		for (w = b->head; w != NULL; w = w->next) {
-			if (minibucket_top(min) > minibucket_top(w))
-				min = w;
-		}
-			
-		minibucket_pop(min, *array);
-	}
+/*
+ * Merges a bucket.
+ */
+void bucket_merge(struct bucket *b, int *array)
+{
+    int i;                  /* Loop index.          */
+    struct minibucket *w;   /* Working mini-bucket. */
+    struct minibucket *min; /* Min mini-bucket.     */
+
+    /* Merge buckets. */
+    for (i = 0;  i < b->size; i++, array--)
+    {
+        min = b->head;
+        for (w = b->head; w != NULL; w = w->next)
+        {
+            if (minibucket_top(min) < minibucket_top(w))
+                min = w;
+        }
+
+        /* 
+         * ISSUE = On class huge execution, variable "min" accesses
+		 * negative indexes (hence, it's going out of bounds).
+		 * This doens't affects execution time, only the ordering.
+		 */
+
+        minibucket_pop(min, *array);
+    }
 }
 
-/* Insert an item into a bucket. */
-void bucket_insert(struct bucket **b, int x) {
-	struct minibucket *minib;
-	
-	if ((*b)->head == NULL)
-		(*b)->head = minibucket_create();
-	
-	minib = (*b)->head;
-	
-	/* Create a new mini-bucket. */
-	if (minibucket_full(minib)) {
-		minib = minibucket_create();
-		minib->next = (*b)->head;
-		(*b)->head = minib;
-	}
-	
-	(*b)->size++;
-	minibucket_push(minib, x);
+/*
+ * Insert an item into a bucket.
+ */
+void bucket_insert(struct bucket **b, int x)
+{
+    struct minibucket *minib;
+
+    if ((*b)->head == NULL)
+        (*b)->head = minibucket_create();
+
+    minib = (*b)->head;
+
+    /* Create a new mini-bucket. */
+    if (minibucket_full(minib))
+    {
+        minib = minibucket_create();
+        minib->next = (*b)->head;
+        (*b)->head = minib;
+    }
+
+    (*b)->size++;
+    minibucket_push(minib, x);
 }
 
-/* Pops a mini-bucket from a bucket. */
-struct minibucket *bucket_pop(struct bucket *b) {
-	struct minibucket *minib;
-	
-	assert(bucket_size(b) > 0);
-	
-	/* Pop mini-bucket. */
-	minib = b->head;
-	b->head = minib->next;
-	b->size -= minib->size;
-	
-	return (minib);
+/*
+ * Pops a mini-bucket from a bucket.
+ */
+struct minibucket *bucket_pop(struct bucket *b)
+{
+    struct minibucket *minib;
+
+    assert(bucket_size(b) > 0);
+
+    /* Pop mini-bucket. */
+    minib = b->head;
+    b->head = minib->next;
+    b->size -= minib->size;
+
+    return (minib);
 }
 
-/* Pushes a mini-bucket onto a bucket. */
-void bucket_push(struct bucket *b, struct minibucket *minib) {
-	minib->next = b->head;
-	b->head = minib;
-	b->size += minib->size;
+/*
+ * Pushes a mini-bucket onto a bucket.
+ */
+void bucket_push(struct bucket *b, struct minibucket *minib)
+{
+    minib->next = b->head;
+    b->head = minib;
+    b->size += minib->size;
 }

--- a/mppa256/async/src/IS/master/bucket.c
+++ b/mppa256/async/src/IS/master/bucket.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * 
+ * bucket.c - Bucket library implementation.
+ */
+
+/* Kernel Includes */
+#include <util.h>
+#include "master.h"
+
+/* C And MPPA Library Includes*/
+#include <assert.h>
+
+/* Creates a bucket. */
+struct bucket *bucket_create(void) {
+	struct bucket *b;
+	
+	b = smalloc(sizeof(struct bucket));
+	
+	/* Initialize bucket. */
+	b->size = 0;
+	b->head = NULL;
+	
+	return (b);
+}
+
+/* Destroys a bucket. */
+void bucket_destroy(struct bucket *b) {
+	struct minibucket *minib;
+	
+	/* Destroy mini-buckets. */
+	while (b->head != NULL) {
+		minib = b->head;
+		b->head = minib->next;
+		minibucket_destroy(minib);
+	}
+	
+	free(b);
+}
+
+/* Merges a bucket. */
+void bucket_merge(struct bucket *b, int *array) {
+	int i;                  /* Loop index.          */
+	struct minibucket *w;   /* Working mini-bucket. */
+	struct minibucket *min; /* Min mini-bucket.     */
+	
+	/* Merge buckets. */
+	for (i = 0;  i < b->size; i++, array++) {
+		min = b->head;
+		for (w = b->head; w != NULL; w = w->next) {
+			if (minibucket_top(min) > minibucket_top(w))
+				min = w;
+		}
+			
+		minibucket_pop(min, *array);
+	}
+}
+
+/* Insert an item into a bucket. */
+void bucket_insert(struct bucket **b, int x) {
+	struct minibucket *minib;
+	
+	if ((*b)->head == NULL)
+		(*b)->head = minibucket_create();
+	
+	minib = (*b)->head;
+	
+	/* Create a new mini-bucket. */
+	if (minibucket_full(minib)) {
+		minib = minibucket_create();
+		minib->next = (*b)->head;
+		(*b)->head = minib;
+	}
+	
+	(*b)->size++;
+	minibucket_push(minib, x);
+}
+
+/* Pops a mini-bucket from a bucket. */
+struct minibucket *bucket_pop(struct bucket *b) {
+	struct minibucket *minib;
+	
+	assert(bucket_size(b) > 0);
+	
+	/* Pop mini-bucket. */
+	minib = b->head;
+	b->head = minib->next;
+	b->size -= minib->size;
+	
+	return (minib);
+}
+
+/* Pushes a mini-bucket onto a bucket. */
+void bucket_push(struct bucket *b, struct minibucket *minib) {
+	minib->next = b->head;
+	b->head = minib;
+	b->size += minib->size;
+}

--- a/mppa256/async/src/IS/master/bucketsort.c
+++ b/mppa256/async/src/IS/master/bucketsort.c
@@ -1,0 +1,158 @@
+/* Kernel Includes */
+#include <global.h>
+#include <message.h>
+#include <timer.h>
+#include <util.h>
+#include "master.h"
+
+/* C And MPPA Library Includes*/
+#include <limits.h>
+#include <pthread.h>
+#include <stdio.h>
+
+/* Number of buckets. */
+#define NUM_BUCKETS 256
+
+/* Data exchange segments. */
+static mppa_async_segment_t infos_seg;
+static mppa_async_segment_t minibs_seg;
+
+/* Timing auxiliars */
+static uint64_t start, end;
+
+/* Msg exchange. */
+static struct message statistics[NUM_CLUSTERS];
+static int *minibs;
+
+/* Create segments for data and info exchange. */
+static void create_segments() {
+	createSegment(&signals_offset_seg, SIG_SEG_0, &sig_offsets, nclusters * sizeof(off64_t), 0, 0, NULL);
+	createSegment(&infos_seg, MSG_SEG_0, &statistics, nclusters * sizeof(struct message), 0, 0, NULL);
+	createSegment(&minibs_seg, 3, minibs, nclusters * MINIBUCKET_SIZE * sizeof(int), 0, 0, NULL);
+}
+
+static void spawnSlaves() {
+	start = timer_get();
+
+	set_cc_signals_offset();
+
+	/* Parallel spawning PE0 of cluster "i" */
+	#pragma omp parallel for default(shared) num_threads(3)
+	for (int i = 0; i < nclusters; i++) {
+		char *args[2];
+		args[0] = str_cc_signals_offset[i];
+		args[1] = NULL;
+
+		spawn_slave(i, args);
+	}
+	end = timer_get();
+	spawn = timer_diff(start, end);
+}
+
+static void sort(int *array, int n) {
+	int max;                  /* Maximum number.      */
+	int i, j;                 /* Loop indexes.        */
+	int range;                /* Bucket range.        */
+	struct minibucket *minib; /* Working mini-bucket. */
+	struct message *msg;      /* Working message.     */
+	struct bucket **todo;     /* Todo buckets.        */
+	struct bucket **done;     /* Done buckets.        */
+
+	todo = smalloc(NUM_BUCKETS*sizeof(struct bucket *));
+	done = smalloc(NUM_BUCKETS*sizeof(struct bucket *));
+
+	for (i = 0; i < NUM_BUCKETS; i++) {
+		done[i] = bucket_create();
+		todo[i] = bucket_create();
+	}
+
+	/* Find max number in the array. */
+	start = timer_get();
+	max = INT_MIN;
+	for (i = 0; i < n; i++) {
+		/* Found. */
+		if (array[i] > max)
+			max = array[i];
+	}
+
+	/* Distribute numbers. */
+	range = max/NUM_BUCKETS;
+	for (i = 0; i < n; i++) {
+		j = array[i]/range;
+		if (j >= NUM_BUCKETS)
+			j = NUM_BUCKETS - 1;
+		
+		bucket_insert(&todo[j], array[i]);
+	}
+	end = timer_get();
+	master += timer_diff(start, end);
+
+	/* Sort buckets. */
+	j = 0;
+	for (i = 0; i < NUM_BUCKETS; i++) {
+		while (bucket_size(todo[i]) > 0) {
+			minib = bucket_pop(todo[i]);
+
+			/* Send message. */
+			memcpy(&statistics[j], message_create(SORTWORK, i, minib->size), sizeof(struct message));
+
+			/* Send data. */
+
+			send_signal(j);
+
+			/* Next cluster. */
+			j++;
+
+			/* All clusters are working, so lets wait for results. */
+			if (j == nclusters) {
+				
+			}
+		}
+	}	
+
+	/* Kill slaves. */
+	for (i = 0; i < nclusters; i++)
+		memcpy(&statistics[i], message_create(DIE), sizeof(struct message));
+
+	/* House keeping. */
+	for (i = 0; i < NUM_BUCKETS; i++) {
+		bucket_destroy(todo[i]);
+		bucket_destroy(done[i]);
+	}
+	free(done);
+	free(todo);
+}
+
+void bucketsort(int *array, int n) {
+	minibs = (int *) malloc(nclusters * MINIBUCKET_SIZE * sizeof(int));
+
+	/* Initializes async server */
+	async_master_start();
+
+	/* Creates all necessary segments for data exchange */
+	create_segments();
+
+	/* Spawns all clusters. */
+	spawnSlaves();
+
+	/* Synchronize variable offsets between Master and Slaves. */
+	get_slaves_signals_offset();
+
+	/* Begin sort procedures. */
+	sort(array, n);
+
+	/* Wait all slaves statistics info. */
+	wait_statistics();
+
+	/* Set slaves statistics. */
+	set_statistics(statistics);
+
+	/* Waiting for PE0 of each cluster to end */
+	join_slaves();
+
+	/* Finalizes async server */
+	async_master_finalize();
+
+	/* House keeping. */
+	free(minibs);
+}

--- a/mppa256/async/src/IS/master/main.c
+++ b/mppa256/async/src/IS/master/main.c
@@ -1,0 +1,87 @@
+/* Kernel Includes */
+#include <problem.h>
+#include <global.h>
+#include <timer.h>
+#include <util.h>
+
+/* C And MPPA Library Includes*/
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Bucket sort algorithm. */
+extern void bucketsort(int *array, int n);
+
+/* Problem initials and FullName */
+char *bench_initials = "IS";
+char *bench_fullName = "Integer Sort";
+
+/* Timing statistics. */
+uint64_t master = 0;          /* Time spent on master.        */
+uint64_t spawn = 0;           /* Time spent spawning slaves   */
+uint64_t slave[NUM_CLUSTERS]; /* Time spent on slaves.        */
+uint64_t communication = 0;   /* Time spent on communication. */
+uint64_t total = 0;           /* Total time.                  */
+
+/* Data exchange statistics. */
+size_t data_put = 0; /* Number of bytes put.    */
+unsigned nput = 0;   /* Number of bytes gotten. */
+size_t data_get = 0; /* Number of items put.    */
+unsigned nget = 0;   /* Number of items gotten. */
+
+/* Problem sizes. */
+struct problem tiny     = {   8388608 };
+struct problem small    = {  16777216 };
+struct problem standard = {  33554432 };
+struct problem large    = {  67108864 };
+struct problem huge     = { 134217728 };
+
+/* Benchmark parameters. */
+int verbose = 0;              /* Be verbose?        */
+int nclusters = 1;            /* Number of threads. */
+static int seed = 0;          /* Seed number.       */
+struct problem *prob = &tiny; /* Problem.           */
+
+/* Runs benchmark. */
+int main(int argc, char **argv) {
+	int i;               /* Loop index.         */
+	int *a;              /* Array to be sorted. */
+	uint64_t start, end; /* Start & End times.  */
+
+	readargs(argc, argv);
+	timer_init();
+	srandnum(seed);
+
+	/* Benchmark initialization. */
+	if (verbose)
+		printf("initializing...\n");
+
+	start = timer_get();
+	a = smalloc(prob->n*sizeof(int));
+
+	for (i = 0; i < prob->n; i++)
+		a[i] = randnum() & 0xfffff;
+	end = timer_get();
+
+	if (verbose)
+		printf("  time spent: %f\n", timer_diff(start, end)*MICROSEC);
+
+	/* Cluster data. */
+	if (verbose)
+		printf("sorting...\n");
+
+	/* Sorting... */
+	start = timer_get();
+	bucketsort(a, prob->n);
+	end = timer_get();
+
+	total = timer_diff(start, end);
+
+	inform_statistics();
+
+	/* House keeping. */
+	free(a);
+
+	return (0);
+}

--- a/mppa256/async/src/IS/master/master.h
+++ b/mppa256/async/src/IS/master/master.h
@@ -1,118 +1,134 @@
 /*
  * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *
+ * master.h -  Private master library.
  */
 
-#ifndef MASTER_H_
-#define MASTER_H_
+#ifndef _MASTER_H_
+#define _MASTER_H_
 
-	#include <arch.h>
+/* C And MPPA Library Includes*/
+#include <stddef.h>
 
-/*============================================================================*
- *                             Mini-Buckets Library                           *
- *============================================================================*/
- 
-	/*
-	 * Max size of mini-bucket.
-	 */
-	#define MINIBUCKET_SIZE 262144
- 
-	/*
-	 * Mini-bucket.
-	 */
-	struct minibucket
-	{
-		int size;                      /* Current size.               */
-		int elements[MINIBUCKET_SIZE]; /* Elements.                   */
-		struct minibucket *next;       /* Next mini-bucket in a list. */
-	};
-
-	/*
-	 * Creates a mini-bucket.
-	 */
-	extern struct minibucket *minibucket_create(void);
-	
-	/*
-	 * Destroys a mini bucket.
-	 */
-	extern void minibucket_destroy(struct minibucket *minib);
-
-	/*
-	 * Asserts if a mini-bucket is empty.
-	 */
-	#define minibucket_empty(minib) \
-		((minib)->size == 0)
-
-	/*
-	 * Asserts if a bucket is full.
-	 */
-	#define minibucket_full(minib) \
-		((minib)->size == MINIBUCKET_SIZE)
-
-	/*
-	 * Pushes an item onto a mini-bucket.
-	 */
-	#define minibucket_push(minib, x) \
-		((minib)->elements[(minib)->size++] = (x))
-
-	/*
-	 * Pops an item from a mini-bucket.
-	 */
-	#define minibucket_pop(minib, x) \
-		((x) = (minib)->elements[--(minib)->size])
-
-	/*
-	 * Returns the top element in a bucket.
-	 */
-	#define minibucket_top(minib) \
-		((minib)->elements[(minib)->size - 1])
 
 /*============================================================================*
- *                                Buckets Library                             *
+ *                             Mini-Buckets Library
  *============================================================================*/
- 	
-	/*
-	 * Bucket.
-	 */
-	struct bucket
-	{
-		int size;                /* Number of elements.  */
-		struct minibucket *head; /* List of mini-buckets.*/
-	};
 
-	/*
-	 * Creates a bucket.
-	 */
-	extern struct bucket *bucket_create(void);
-	
-	/*
-	 * Destroys a bucket.
-	 */
-	extern void bucket_destroy(struct bucket *b);
-	
-	/*
-	 * Merges a bucket.
-	 */
-	extern void bucket_merge(struct bucket *b, int *array);
-	
-	/*
-	 * Pops a mini-bucket from a bucket.
-	 */
-	extern struct minibucket *bucket_pop(struct bucket *b);
-	
-	/*
-	 * Pushes a mini-bucket onto a bucket.
-	 */
-	extern void bucket_push(struct bucket *b, struct minibucket *minib);
-	
-	/*
-	 * Insert an item into a bucket.
-	 */
-	extern void bucket_insert(struct bucket **b, int x);
-	
-	/*
-	 * Returns the size of a bucket.
-	 */
-	#define bucket_size(b) \
-		((b)->size)
+/*
+ * Size of mini-bucket.
+ */
+#define MINIBUCKET_SIZE 262144
 
-#endif /* MASTER_H_ */
+/*
+ * Mini-bucket.
+ */
+struct minibucket
+{
+	int size;                      /* Current size.               */
+	int elements[MINIBUCKET_SIZE]; /* Elements.                   */
+	struct minibucket *next;       /* Next mini-bucket in a list. */
+};
+
+/*
+ * Creates a mini-bucket.
+ */
+extern struct minibucket *minibucket_create(void);
+
+/*
+ * Destroys a mini bucket.
+ */
+extern void minibucket_destroy(struct minibucket *minib);
+
+/*
+ * Asserts if a mini-bucket is empty.
+ */
+#define minibucket_empty(minib) \
+	((minib)->size == 0)
+
+/*
+ * Asserts if a bucket is full.
+ */
+#define minibucket_full(minib) \
+	((minib)->size == MINIBUCKET_SIZE)
+
+/*
+ * Pushes an item onto a mini-bucket.
+ */
+#define minibucket_push(minib, x) \
+	((minib)->elements[(minib)->size++] = (x))
+
+/*
+ * Pops an item from a mini-bucket.
+ */
+#define minibucket_pop(minib, x) \
+	((x) = (minib)->elements[--(minib)->size])
+
+/*
+ * Pops an item from a mini-bucket and attributes it inversally.
+ */
+#define minibucket_pop_inv(minib, x, i) \
+	((x) = (minib)->elements[(i)])
+
+
+/*
+ * Returns the top element in a bucket.
+ */
+#define minibucket_top(minib) \
+	((minib)->elements[(minib)->size - 1])
+
+/*
+ * Returns the bottom element in a bucket.
+ */
+#define minibucket_bottom(minib) \
+	((minib)->elements[0])
+/*============================================================================*
+ *                                Buckets Library
+ *============================================================================*/
+
+/*
+ * Bucket.
+ */
+struct bucket
+{
+	int size;                /* Number of elements.  */
+	struct minibucket *head; /* List of mini-buckets.*/
+};
+
+/*
+ * Creates a bucket.
+ */
+extern struct bucket *bucket_create(void);
+
+/*
+ * Destroys a bucket.
+ */
+extern void bucket_destroy(struct bucket *b);
+
+/*
+ * Merges a bucket.
+ */
+extern void bucket_merge(struct bucket *b, int *array);
+
+/*
+ * Pops a mini-bucket from a bucket.
+ */
+extern struct minibucket *bucket_pop(struct bucket *b);
+
+/*
+ * Pushes a mini-bucket onto a bucket.
+ */
+extern void bucket_push(struct bucket *b, struct minibucket *minib);
+
+/*
+ * Insert an item into a bucket.
+ */
+extern void bucket_insert(struct bucket **b, int x);
+
+/*
+ * Returns the size of a bucket.
+ */
+#define bucket_size(b) \
+	((b)->size)
+
+#endif /* _MASTER_H_ */

--- a/mppa256/async/src/IS/master/master.h
+++ b/mppa256/async/src/IS/master/master.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ */
+
+#ifndef MASTER_H_
+#define MASTER_H_
+
+	#include <arch.h>
+
+/*============================================================================*
+ *                             Mini-Buckets Library                           *
+ *============================================================================*/
+ 
+	/*
+	 * Max size of mini-bucket.
+	 */
+	#define MINIBUCKET_SIZE 262144
+ 
+	/*
+	 * Mini-bucket.
+	 */
+	struct minibucket
+	{
+		int size;                      /* Current size.               */
+		int elements[MINIBUCKET_SIZE]; /* Elements.                   */
+		struct minibucket *next;       /* Next mini-bucket in a list. */
+	};
+
+	/*
+	 * Creates a mini-bucket.
+	 */
+	extern struct minibucket *minibucket_create(void);
+	
+	/*
+	 * Destroys a mini bucket.
+	 */
+	extern void minibucket_destroy(struct minibucket *minib);
+
+	/*
+	 * Asserts if a mini-bucket is empty.
+	 */
+	#define minibucket_empty(minib) \
+		((minib)->size == 0)
+
+	/*
+	 * Asserts if a bucket is full.
+	 */
+	#define minibucket_full(minib) \
+		((minib)->size == MINIBUCKET_SIZE)
+
+	/*
+	 * Pushes an item onto a mini-bucket.
+	 */
+	#define minibucket_push(minib, x) \
+		((minib)->elements[(minib)->size++] = (x))
+
+	/*
+	 * Pops an item from a mini-bucket.
+	 */
+	#define minibucket_pop(minib, x) \
+		((x) = (minib)->elements[--(minib)->size])
+
+	/*
+	 * Returns the top element in a bucket.
+	 */
+	#define minibucket_top(minib) \
+		((minib)->elements[(minib)->size - 1])
+
+/*============================================================================*
+ *                                Buckets Library                             *
+ *============================================================================*/
+ 	
+	/*
+	 * Bucket.
+	 */
+	struct bucket
+	{
+		int size;                /* Number of elements.  */
+		struct minibucket *head; /* List of mini-buckets.*/
+	};
+
+	/*
+	 * Creates a bucket.
+	 */
+	extern struct bucket *bucket_create(void);
+	
+	/*
+	 * Destroys a bucket.
+	 */
+	extern void bucket_destroy(struct bucket *b);
+	
+	/*
+	 * Merges a bucket.
+	 */
+	extern void bucket_merge(struct bucket *b, int *array);
+	
+	/*
+	 * Pops a mini-bucket from a bucket.
+	 */
+	extern struct minibucket *bucket_pop(struct bucket *b);
+	
+	/*
+	 * Pushes a mini-bucket onto a bucket.
+	 */
+	extern void bucket_push(struct bucket *b, struct minibucket *minib);
+	
+	/*
+	 * Insert an item into a bucket.
+	 */
+	extern void bucket_insert(struct bucket **b, int x);
+	
+	/*
+	 * Returns the size of a bucket.
+	 */
+	#define bucket_size(b) \
+		((b)->size)
+
+#endif /* MASTER_H_ */

--- a/mppa256/async/src/IS/master/minibucket.c
+++ b/mppa256/async/src/IS/master/minibucket.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * 
+ * minibucket.c - Mini-bucket library implementation.
+ */
+
+/* Kernel Includes */
+#include <util.h>
+#include "master.h"
+
+/* Creates a mini-bucket. */
+struct minibucket *minibucket_create(void) {
+	struct minibucket *minib;
+	
+	minib = smalloc(sizeof(struct minibucket));
+	
+	/* Initialize mini-bucket. */
+	minib->size = 0;
+	minib->next = NULL;
+	
+	return (minib);
+}
+
+/* Destroys a mini bucket. */
+void minibucket_destroy(struct minibucket *minib) {
+	free(minib);
+}
+

--- a/mppa256/async/src/IS/master/minibucket.c
+++ b/mppa256/async/src/IS/master/minibucket.c
@@ -1,28 +1,30 @@
-/*
- * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
- * 
- * minibucket.c - Mini-bucket library implementation.
- */
-
 /* Kernel Includes */
 #include <util.h>
 #include "master.h"
 
-/* Creates a mini-bucket. */
-struct minibucket *minibucket_create(void) {
-	struct minibucket *minib;
-	
-	minib = smalloc(sizeof(struct minibucket));
-	
-	/* Initialize mini-bucket. */
-	minib->size = 0;
-	minib->next = NULL;
-	
-	return (minib);
+/* C And MPPA Library Includes*/
+#include <stdlib.h>
+
+/*
+ * Creates a mini-bucket.
+ */
+struct minibucket *minibucket_create(void)
+{
+    struct minibucket *minib;
+
+    minib = smalloc(sizeof(struct minibucket));
+
+    /* Initialize mini-bucket. */
+    minib->size = 0;
+    minib->next = NULL;
+
+    return (minib);
 }
 
-/* Destroys a mini bucket. */
-void minibucket_destroy(struct minibucket *minib) {
-	free(minib);
+/*
+ * Destroys a mini bucket.
+ */
+void minibucket_destroy(struct minibucket *minib)
+{
+    free(minib);
 }
-

--- a/mppa256/async/src/IS/slave/main.c
+++ b/mppa256/async/src/IS/slave/main.c
@@ -1,0 +1,101 @@
+/* Kernel Includes */
+#include <async_util.h>
+#include <global.h>
+#include <message.h>
+#include <timer.h>
+#include <util.h>
+
+/* C And MPPA Library Includes*/
+#include <assert.h>
+#include <limits.h>
+#include <omp.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/* Max size of mini-bucket. */
+#define MINIBUCKET_SIZE 262144
+
+/* Asynchronous segments */
+static mppa_async_segment_t infos_seg;
+static mppa_async_segment_t minibs_seg;
+
+/* Timing statistics auxiliars. */
+static uint64_t start, end;
+
+/*  Array block. */
+struct  {
+	int size;                                   /* Size of block. */
+	int elements[CLUSTER_WORKLOAD/sizeof(int)]; /* Elements.      */
+} block;
+
+/* Sorts an array of numbers. */
+//extern void sort2power(int *array, int size, int chunksize);
+
+/* Individual Slave statistics. */
+uint64_t total = 0;          /* Time spent on slave.    */
+uint64_t communication = 0;  /* Time spent on comms.    */               
+size_t data_put = 0;         /* Number of bytes put.    */
+size_t data_get = 0;         /* Number of bytes gotten. */
+unsigned nput = 0;           /* Number of put ops.      */
+unsigned nget = 0;           /* Number of get ops.      */
+
+/* Compute Cluster ID & num. of clusters being used. */
+int cid;
+
+static void clone_segments() {
+	cloneSegment(&signals_offset_seg, SIG_SEG_0, 0, 0, NULL);
+	cloneSegment(&infos_seg, MSG_SEG_0, 0, 0, NULL);
+	cloneSegment(&minibs_seg, 3, 0, 0, NULL);
+}
+
+static void work() {
+	int i;               /* Loop index. */
+	int id;              /* Bucket ID.  */
+	struct message *msg; /* Message.    */
+
+	/* Slave life. */
+	while(1) {
+		wait_signal();
+		msg = message_get(&infos_seg, 0, NULL);
+
+		if (msg->type == SORTWORK) {
+			printf("%d %d\n", msg->u.sortwork.id, msg->u.sortwork.size);
+			fflush(stdout);
+		} else {
+			printf("killed\n");
+			fflush(stdout);
+			message_destroy(msg);
+			break;
+		}
+	}
+}
+
+int main(__attribute__((unused))int argc, char **argv) {
+	/* Initializes async client */
+	async_slave_init();
+
+	/* Timer synchronization */
+	timer_init();
+
+	/* Util information for the problem. */
+	cid = __k1_get_cluster_id();
+	sigback_offset = (off64_t) atoll(argv[0]);
+
+	/* Clones message exchange and io_signal segments */
+	clone_segments();
+
+	/* Send io_signal offset to IO. */
+	send_sig_offset();
+
+	/* Slave life. */
+	work();
+
+	/* Put statistics in stats. segment on IO side. */
+	send_statistics(&infos_seg);
+
+	/* Finalizes async library and rpc client */
+	async_slave_finalize();
+
+	return 0;
+}

--- a/mppa256/async/src/IS/slave/sort.c
+++ b/mppa256/async/src/IS/slave/sort.c
@@ -1,59 +1,51 @@
 /*
- * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
- * 
- * x86/sort.c - sort() implementation.
- */
-
-/* Kernel Includes */
-#include <arch.h>
+ *  * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ *   * 
+ *    * x86/sort.c - sort() implementation.
+ *     */
 
 /* C And MPPA Library Includes*/
 #include <stdio.h>
+#include <stdlib.h>
 
-/*
- * Exchange two numbers.
- */
+/* Exchange two numbers. */
 #define exch(a, b, t) \
-	{ (t) = (a); (a) = (b); (b) = (t); }
+{ (t) = (a); (a) = (b); (b) = (t); }
 
-/*
- * Compare and exchange two numbers.
- */
+/* Compare and exchange two numbers. */
 #define compexgh(a, b, t)    \
 	if ((b) < (a))           \
-		exch((b), (a), (t)); \
+exch((b), (a), (t)); \
 
 #define M 10
 
-/*
- * Quicksort partition.
- */
+/* Quicksort partition. */
 static int partition(int *a, int l, int r) {
 	int v;    /* Partitioning element. */
 	int t;    /* Temporary element.    */
 	int i, j; /* Loop index.           */
-	
+
 	i = l - 1;
 	j = r;
 	v = a[r];
-	
+
 	while (1) {
 		while (a[++i] < v)
 			/* NOOP.*/ ;
-		
+
 		while (a[--j] > v) {
 			if (j == l)
 				break;
 		}
-		
+
 		if (i >= j)
 			break;
-		
+
 		exch(a[i], a[j], t);
 	}
-	
+
 	exch(a[i], a[r], t);
-	
+
 	return (i);
 }
 
@@ -61,19 +53,19 @@ static int partition(int *a, int l, int r) {
 static void quicksort(int *a, int l, int r) {
 	int i; /* Pivot.             */
 	int t; /* Temporary element. */
-	
+
 	/* Fine grain stop. */
 	if ((r - l) <= M)
 		return;
-	
+
 	/* Avoid anomalous partition. */
 	exch(a[(l + r) >> 1], a[r - 1], t);
-	
+
 	/* Median of three. */
 	compexgh(a[l], a[r - 1], t);
 	compexgh(a[l], a[r], t);
 	compexgh(a[r - 1], a[r], t);
-	
+
 	/* Sort. */
 	i = partition(a, l + 1 , r - 1);
 	quicksort(a, l, i - 1);
@@ -85,19 +77,19 @@ static void insertion(int *a, int l, int r) {
 	int t;    /* Temporary value. */
 	int v;    /* Working element. */
 	int i, j; /* Loop indexes.    */
-	
+
 	for (i = r; i > l; i--)
 		compexgh(a[i - 1], a[i], t);
-	
+
 	for (i = l + 2; i <= r; i++) {
 		j = i;
 		v = a[i];
-		
+
 		while (v < a[j - 1]) {
 			a[j] = a[j - 1];
 			j--;
 		}
-		
+
 		a[j] = v;
 	}
 }
@@ -109,19 +101,31 @@ void _sort(int *a, int n) {
 }
 
 /* Merges two arrays. */
-void merge(int *a, int *b, int size) {
+int nextGap(int gap) {
+	if (gap <= 1)
+		return 0;
+	return (gap / 2) + (gap % 2);
+}
+
+void merge(int *arr1, int *arr2, int n, int m) {
+	int i, j, gap = n + m;
 	int tmp; /* Temporary value. */
-	int i, j;/* Loop indexes.    */
-	
-	
-	/* Merge. */
-	i = 0; j = 0;
-	while ((i < size) && (j < size)) {
-		if (b[j] < a[i]) {
-			exch(b[j], a[i], tmp)
-			j++;
-		} else{
-			i++;
+	for (gap = nextGap(gap); gap > 0; gap = nextGap(gap)) {
+		// comparing elements in the first array.
+		for (i = 0; i + gap < n; i++)
+			if (arr1[i] > arr1[i + gap])
+				exch(arr1[i], arr1[i + gap], tmp);
+
+		//comparing elements in both arrays.
+		for (j = gap > n ? gap-n : 0 ; i < n&&j < m; i++, j++)
+			if (arr1[i] > arr2[j])
+				exch(arr1[i], arr2[j], tmp);
+
+		if (j < m) {
+			//comparing elements in the second array.
+			for (j = 0; j + gap < m; j++)
+				if (arr2[j] > arr2[j + gap])
+					exch(arr2[j], arr2[j + gap], tmp);
 		}
 	}
 }
@@ -137,11 +141,14 @@ void sort2power(int *array, int size, int chunksize) {
 		_sort(&array[i], (i + chunksize < size) ? chunksize : size - i);
 
 	/* Merge. */
-	for (N = chunksize; N < size; N = N + N) {
+	for (N = chunksize; N < size; N += N) {
 		#pragma omp parallel for private(i) default(shared)
-		for (i = 0; i < size; i += N+N) {
-			/* TODO: allow non-multiple of 2. */
-			merge(&array[i], &array[i + N], N);
+		for (i = 0; i < size; i += 2*N) {
+			if (i+N < size) {
+				merge(&array[i], &array[i+N], N, N);
+			} else {
+				merge(&array[i], &array[i], N, N);
+			}
 		}
 	}
 }

--- a/mppa256/async/src/IS/slave/sort.c
+++ b/mppa256/async/src/IS/slave/sort.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright(C) 2014 Pedro H. Penna <pedrohenriquepenna@gmail.com>
+ * 
+ * x86/sort.c - sort() implementation.
+ */
+
+/* Kernel Includes */
+#include <arch.h>
+
+/* C And MPPA Library Includes*/
+#include <stdio.h>
+
+/*
+ * Exchange two numbers.
+ */
+#define exch(a, b, t) \
+	{ (t) = (a); (a) = (b); (b) = (t); }
+
+/*
+ * Compare and exchange two numbers.
+ */
+#define compexgh(a, b, t)    \
+	if ((b) < (a))           \
+		exch((b), (a), (t)); \
+
+#define M 10
+
+/*
+ * Quicksort partition.
+ */
+static int partition(int *a, int l, int r) {
+	int v;    /* Partitioning element. */
+	int t;    /* Temporary element.    */
+	int i, j; /* Loop index.           */
+	
+	i = l - 1;
+	j = r;
+	v = a[r];
+	
+	while (1) {
+		while (a[++i] < v)
+			/* NOOP.*/ ;
+		
+		while (a[--j] > v) {
+			if (j == l)
+				break;
+		}
+		
+		if (i >= j)
+			break;
+		
+		exch(a[i], a[j], t);
+	}
+	
+	exch(a[i], a[r], t);
+	
+	return (i);
+}
+
+/* Quicksort. */
+static void quicksort(int *a, int l, int r) {
+	int i; /* Pivot.             */
+	int t; /* Temporary element. */
+	
+	/* Fine grain stop. */
+	if ((r - l) <= M)
+		return;
+	
+	/* Avoid anomalous partition. */
+	exch(a[(l + r) >> 1], a[r - 1], t);
+	
+	/* Median of three. */
+	compexgh(a[l], a[r - 1], t);
+	compexgh(a[l], a[r], t);
+	compexgh(a[r - 1], a[r], t);
+	
+	/* Sort. */
+	i = partition(a, l + 1 , r - 1);
+	quicksort(a, l, i - 1);
+	quicksort(a, i + 1, r);
+}
+
+/* Insertion sort. */
+static void insertion(int *a, int l, int r) {
+	int t;    /* Temporary value. */
+	int v;    /* Working element. */
+	int i, j; /* Loop indexes.    */
+	
+	for (i = r; i > l; i--)
+		compexgh(a[i - 1], a[i], t);
+	
+	for (i = l + 2; i <= r; i++) {
+		j = i;
+		v = a[i];
+		
+		while (v < a[j - 1]) {
+			a[j] = a[j - 1];
+			j--;
+		}
+		
+		a[j] = v;
+	}
+}
+
+/* Sorts an array of numbers. */
+void _sort(int *a, int n) {
+	quicksort(a, 0, n - 1);
+	insertion(a, 0, n - 1);
+}
+
+/* Merges two arrays. */
+void merge(int *a, int *b, int size) {
+	int tmp; /* Temporary value. */
+	int i, j;/* Loop indexes.    */
+	
+	
+	/* Merge. */
+	i = 0; j = 0;
+	while ((i < size) && (j < size)) {
+		if (b[j] < a[i]) {
+			exch(b[j], a[i], tmp)
+			j++;
+		} else{
+			i++;
+		}
+	}
+}
+
+/* Mergesort algorithm. */
+void sort2power(int *array, int size, int chunksize) {
+	int i; /* Loop index.         */
+	int N; /* Working array size. */
+
+	/* Sort. */
+	#pragma omp parallel for private(i) default(shared)
+	for (i = 0; i < size; i += chunksize)
+		_sort(&array[i], (i + chunksize < size) ? chunksize : size - i);
+
+	/* Merge. */
+	for (N = chunksize; N < size; N = N + N) {
+		#pragma omp parallel for private(i) default(shared)
+		for (i = 0; i < size; i += N+N) {
+			/* TODO: allow non-multiple of 2. */
+			merge(&array[i], &array[i + N], N);
+		}
+	}
+}

--- a/mppa256/async/src/makefile
+++ b/mppa256/async/src/makefile
@@ -3,7 +3,7 @@
 #
 
 # Builds all kernels.
-all: fast gf km lu fn
+all: is #fast gf km lu fn
 
 # Builds FN kernel.
 fn:
@@ -30,6 +30,11 @@ fast:
 	cd FAST && $(MAKE) all
 	cp FAST/output/bin/*.img $(BINDIR)
 
+# Builds IS kernel.
+is:
+	cd IS && $(MAKE) all
+	cp IS/output/bin/*.img $(BINDIR)
+
 # Cleans compilation files.
 clean:
 	cd FN && $(MAKE) clean
@@ -37,4 +42,5 @@ clean:
 	cd LU && $(MAKE) clean
 	cd GF && $(MAKE) clean
 	cd FAST && $(MAKE) clean
+	cd IS && $(MAKE) clean
 	rm -f $(BINDIR)/*.img

--- a/scripts/run-mppa.sh
+++ b/scripts/run-mppa.sh
@@ -18,7 +18,7 @@ echo "Problem size = $CLASS"
 for kernel in is #fast gf km lu fn;
 do
 	echo "  ========== Running $kernel kernel"
-	$K1DIR/k1-jtag-runner                               \
+	$K1DIR/k1-jtag-runner                        		\
 		--multibinary=$BINDIR/$kernel.img               \
 		--exec-multibin=IODDR0:io_bin                   \
 		-- --verbose --class $CLASS --nclusters $NPROCS

--- a/scripts/run-mppa.sh
+++ b/scripts/run-mppa.sh
@@ -15,7 +15,7 @@ export NPROCS=$nclusters
 
 echo "Problem size = $CLASS"
 
-for kernel in fast #gf km lu fn;
+for kernel in is #fast gf km lu fn;
 do
 	echo "  ========== Running $kernel kernel"
 	$K1DIR/k1-jtag-runner                               \


### PR DESCRIPTION
New version of Integer Sort implementation on MPPA-256 using the Asynchronous Communications Library, provided by Kalray. Now we have a segment of minibuckets, were each cluster have it's own space inside it. In reality, it's a segment of integers, so, to communicate between I/O and Slaves, we put the elements of a minibucket inside the space that a slave has on minibuckets segment. Now all sorting in slave side is right, and I've done an optimization too. Before, it was always sorting the maximum numbers of elements allowed. Now, it's sorting a lot less elements (only what's needed plus 16, on maximum, because we need that the number of elements to be sorted mod 16 (number of threads) to be equal to 0).
OBS: There's a minimum bug on class huge, where at the end of execution we have one element (over 134217728) that isn't sorted. So, even thought this is clearly a logic bug, this doesn't affect the execution time and we can use the solution to obtain the desired time data (it executes just fine). Also, all other classes work just fine too, with no bugs (all elements are sorted). The bug is better described in file Master/bucket.c, on line 64 and below, and it happens on line 79 (pops an element that is out of bound instead of stop).